### PR TITLE
Relax pydantic version constraint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,14 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
+
+  ha-compat:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Check installability with latest Home Assistant
+        run: uv venv && uv pip install "homeassistant>=2024.12.0" . && uv pip check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Library to interact with the local GARDENA smart API."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "aiofile>=3.9.0",
-    "pydantic>=2.12.5",
-    "pyyaml>=6.0.3",
+    "aiofile>=3.9",
+    "pydantic>=2.0",
+    "pyyaml>=6.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gardena-smart-local-api"
-version = "0.0.1"
+version = "0.0.2"
 description = "Library to interact with the local GARDENA smart API."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Problem

Home Assistant pins `pydantic==2.12.2`, but `gardena-smart-local-api` required `pydantic>=2.12.5`, causing a dependency conflict when using this library in HA.

## Solution

Relax the pydantic constraint to `>=2.0` so the library is compatible with HA's pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)