### PR TITLE
Add Sensor device support (model 18845)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Enables controlling and monitoring GARDENA smart devices in the local network, w
 
 ## Supported Devices
 
-| Model | Device |
-|-------|--------|
-| 18869 | Water Control |
+| Device | Article Number | Model (EAN suffix) |
+|--------|----------------|--------------------|
+| smart Sensor | 19030-20 | 18845 |
+| smart Water Control | 19031-20 | 18869 |
 
 ## Installation
 

--- a/gardena_smart_local_api/devices/__init__.py
+++ b/gardena_smart_local_api/devices/__init__.py
@@ -5,12 +5,14 @@ from .device_builder import (
 )
 from .irrigation import Gen1WaterControl
 from .mowers import Gen1Mower
+from .sensors import Sensor1
 
 __all__ = [
     "Device",
     "DeviceMap",
     "Gen1Mower",
     "Gen1WaterControl",
+    "Sensor1",
     "build_discovery_obj",
     "create_devices_from_json",
     "create_devices_from_messages",

--- a/gardena_smart_local_api/devices/device_builder.py
+++ b/gardena_smart_local_api/devices/device_builder.py
@@ -4,8 +4,10 @@ from ..messages import IngressMessageList, Reply
 from .device import Device, DeviceMap
 from .irrigation import Gen1WaterControl
 from .mowers import Gen1Mower
+from .sensors import Sensor1
 
 MODEL_NUMBER_MAP: dict[str, type[Device]] = {
+    "18845": Sensor1,
     "18869": Gen1WaterControl,
     "53988": Gen1Mower,
 }

--- a/gardena_smart_local_api/devices/sensors.py
+++ b/gardena_smart_local_api/devices/sensors.py
@@ -1,0 +1,79 @@
+from ..messages import EgressMessageList
+from ..resources import IpsoPath
+from .gen1 import Gen1BatteryPoweredGen1Device
+
+
+class Sensor1(Gen1BatteryPoweredGen1Device):
+    @property
+    def temperature(self) -> int | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="ambient_temperature",
+            )
+        )
+        if isinstance(value, int):
+            return value
+        return None
+
+    def build_reload_temperature_obj(self) -> EgressMessageList:
+        return self.build_command_obj(self.get_command("measure_ambient_temperature"))
+
+    @property
+    def light(self) -> int | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="light",
+            )
+        )
+        if isinstance(value, int):
+            return value
+        return None
+
+    def build_reload_light_obj(self) -> EgressMessageList:
+        return self.build_command_obj(self.get_command("measure_light"))
+
+    @property
+    def soil_moisture(self) -> int | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="soil_humidity",
+            )
+        )
+        if isinstance(value, int):
+            return value
+        return None
+
+    def build_reload_soil_moisture_obj(self) -> EgressMessageList:
+        return self.build_command_obj(self.get_command("measure_soil_moisture"))
+
+    @property
+    def has_frost_warning(self) -> bool | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="frost_warning",
+            )
+        )
+        if isinstance(value, int):
+            return bool(value)
+        return None
+
+    @property
+    def error(self) -> int | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="error",
+            )
+        )
+        if isinstance(value, int):
+            return value
+        return None

--- a/gardena_smart_local_api/examples/sensor.py
+++ b/gardena_smart_local_api/examples/sensor.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import asyncio
+import sys
+
+from gardena_smart_local_api.devices import Sensor1
+from gardena_smart_local_api.examples import ExampleApp
+
+
+async def main():
+    extra_args = [
+        {
+            "name_or_flags": ["command"],
+            "nargs": 1,
+            "choices": ("list", "read"),
+            "help": "List devices or read sensor values",
+        },
+    ]
+
+    async with ExampleApp(extra_args) as app:
+        match app.args.command[0]:
+            case "list":
+                for dev_id, device in app.devices.items():
+                    print(f"{dev_id} ({device.model_definition.type})")
+
+            case "read":
+                if app.args.device_id is None:
+                    print("No device ID provided")
+                    return 1
+                sensor = app.devices[app.args.device_id]
+                if not isinstance(sensor, Sensor1):
+                    print("Incompatible device selected")
+                    return 1
+                print(f"Sensor {sensor.id}:")
+                print(f"  Temperature:     {sensor.temperature}°C")
+                print(f"  Soil moisture:   {sensor.soil_moisture}%")
+                print(f"  Light:           {sensor.light} lx")
+                print(f"  Battery:         {sensor.battery_level}%")
+                print(f"  RF link quality: {sensor.rf_link_quality}%")
+                print(f"  Frost warning:   {sensor.has_frost_warning}")
+                print(f"  Error:           {sensor.error}")
+
+
+if __name__ == "__main__":
+    rc = asyncio.run(main())
+    sys.exit(rc)

--- a/gardena_smart_local_api/schema/device_models.yaml
+++ b/gardena_smart_local_api/schema/device_models.yaml
@@ -9,6 +9,234 @@ types:
   ai: list[int]
   as: list[str]
 models:
+  '18845':
+    name: Sensor
+    type: Sensor
+    protocol: gen1
+    commands:
+      measure_soil_moisture: 2
+      measure_soil_temperature: 3
+      measure_light: 4
+      measure_ambient_temperature: 5
+      measure_battery: 6
+      measure_rf_link: 7
+      reboot: 31
+      emc_test_start: 29
+      emc_test_stop: 30
+      force_report: 50
+    objects:
+      connection_status:
+        mandatory: true
+        resources:
+          online:
+            type: vb
+            access: r
+            description: Indicates if the device is online (true) or offline (false)
+      device:
+        mandatory: true
+        resources:
+          device_type:
+            type: vs
+            access: r
+            description: Type of the device
+          error_code:
+            type: ai
+            access: r
+            description: Current error code(s)
+          firmware_version:
+            type: vs
+            access: r
+            description: Current firmware version
+          hardware_version:
+            type: vs
+            access: r
+            description: Hardware version
+          manufacturer:
+            type: vs
+            access: r
+            description: Manufacturer name
+          model_number:
+            type: vs
+            access: r
+            description: Model number or identifier
+          serial_number:
+            type: vs
+            access: r
+            description: Serial number
+          software_version:
+            type: vs
+            access: r
+            description: Current software version
+          supported_binding_and_modes:
+            type: vs
+            access: r
+            description: Supported bindings and modes
+          utc_offset:
+            type: vs
+            access: rw
+            description: UTC offset currently in effect for device
+      firmware_update:
+        mandatory: true
+        resources:
+          firmware_update_delivery_method:
+            type: vi
+            access: r
+            description: Firmware update delivery method
+          package_uri:
+            type: vs
+            access: rw
+            description: URI from where the device can download the firmware package
+          pkg_version:
+            type: vs
+            access: r
+            description: Package version
+          state:
+            type: vi
+            access: r
+            min: 0
+            max: 3
+            description: 'Firmware update state: 0=Idle, 1=Downloading, 2=Downloaded, 3=Updating'
+          update_result:
+            type: vi
+            access: r
+            min: 0
+            max: 9
+            description: 'Update result: 0=Initial, 1=Success, 2=Not enough storage, 3=Out of memory, 4=Connection lost, 5=CRC check failure, 6=Unsupported package type, 7=Invalid URI, 8=Update failed, 9=Unsupported protocol'
+      lemonbeat:
+        resources:
+          ambient_temperature:
+            type: vi
+            access: r
+            unit: C
+            min: -30
+            max: 85
+            report_on_update: true
+            report_interval: 3600
+            description: Ambient temperature (not currently used)
+          battery_level:
+            type: vi
+            access: r
+            unit: '%'
+            min: 0
+            max: 100
+            report_on_update: true
+            description: Battery level (100% is full)
+          chilled_temperature:
+            type: vi
+            access: null
+          command:
+            type: vi
+            access: rw
+            report_on_update: true
+            description: Command to execute
+          cooldown_time:
+            type: vi
+            access: null
+          disposable_battery_lifecycle:
+            type: vi
+            access: null
+          error:
+            type: vi
+            access: r
+            report_on_update: true
+            description: Error status (none, eeprom, brown_out)
+          fatal_error_log:
+            type: vo
+            access: r
+            report_on_update: true
+            description: Fatal error log
+          frost_warning:
+            type: vi
+            access: r
+            min: 0
+            max: 1
+            report_on_update: true
+            report_interval: 3600
+            description: Frost warning if temperature falls below +5°C (1=frost, 0=no frost)
+          heated_temperature:
+            type: vi
+            access: null
+          heating_timestamp:
+            type: vo
+            access: null
+          light:
+            type: vi
+            access: r
+            unit: lx
+            min: 0
+            max: 200000
+            report_on_update: true
+            report_interval: 3600
+            description: Light intensity in lux
+          rf_link_quality:
+            type: vi
+            access: r
+            unit: '%'
+            min: 0
+            max: 100
+            report_on_update: true
+            description: RF link quality percentage
+          rf_link_state:
+            type: vi
+            access: r
+            report_on_update: true
+            description: RF link state
+          soil_humidity:
+            type: vi
+            access: r
+            unit: '%'
+            min: 0
+            max: 100
+            report_on_update: true
+            report_interval: 14400
+            description: Soil moisture value (mean weighted)
+          soil_humidity_raw_value:
+            type: vi
+            access: r
+            unit: '%'
+            min: 0
+            max: 100
+            report_on_update: true
+            report_interval: 14400
+            description: Soil moisture value as measured
+          soil_temperature:
+            type: vi
+            access: r
+            unit: C
+            min: -30
+            max: 85
+            report_on_update: true
+            report_interval: 3600
+            description: Ground temperature
+          threshold:
+            type: vi
+            access: null
+          voltage_log:
+            type: vo
+            access: null
+      lemonbeat_status_message:
+        mandatory: false
+        resources:
+          code:
+            type: vi
+            access: r
+            description: Status code
+          data:
+            type: vs
+            access: r
+            description: Additional status data (4 bytes HEX)
+          level:
+            type: vi
+            access: r
+            min: 0
+            max: 5
+            description: 'Message level: 0=Disabled, 1=Important, 2=Error, 3=Warning, 4=Info, 5=Debug'
+          type:
+            type: vi
+            access: r
+            min: 0
+            max: 255
+            description: Message type
   '18869':
     name: Water Control
     type: Water Control

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,3 +65,37 @@ def unknown_device_json():
 @pytest.fixture
 def unknown_device(unknown_device_json):
     return IngressMessageList.model_validate_json(unknown_device_json)
+
+
+@pytest.fixture
+def sensor1_json():
+    data_file = Path(__file__).parent / "data" / "sensor1.json"
+    with open(data_file) as f:
+        return f.read()
+
+
+@pytest.fixture
+def sensor1_message(sensor1_json):
+    return IngressMessageList.model_validate_json(sensor1_json)
+
+
+@pytest_asyncio.fixture
+async def sensor1(sensor1_message):
+    return list((await create_devices_from_messages(sensor1_message)).values())[0]
+
+
+@pytest.fixture
+def sensor1_update_event_json():
+    data_file = Path(__file__).parent / "data" / "sensor1_update_event.json"
+    with open(data_file) as f:
+        return f.read()
+
+
+@pytest.fixture
+def sensor1_update_event(sensor1_update_event_json):
+    return IngressMessageList.model_validate_json(sensor1_update_event_json)
+
+
+@pytest.fixture
+def sensor1_and_update_event(sensor1_message, sensor1_update_event):
+    return sensor1_message + sensor1_update_event

--- a/tests/data/sensor1.json
+++ b/tests/data/sensor1.json
@@ -1,0 +1,66 @@
+[
+  {
+    "entity": { "path": "devices", "service": "lemonbeatd" },
+    "metadata": { "sequence": 3806, "source": "lemonbeatd" },
+    "payload": {
+      "3034F8EE901267400000B333": {
+        "connection_status": {
+          "0": { "online": { "ts": 1768826098, "vb": true } },
+          "_urn": "urn:oma:lwm2m:x:28171"
+        },
+        "device": {
+          "0": {
+            "device_type": { "ts": 1769328781, "vs": "Sensor" },
+            "error_code": { "ai": [0], "ts": 1769328781 },
+            "firmware_version": { "ts": 1769328781, "vs": "4.0.0-1.6.1" },
+            "hardware_version": { "ts": 1769328781, "vs": "1.0.3" },
+            "manufacturer": { "ts": 1769328781, "vs": "Gardena" },
+            "model_number": { "ts": 1769328781, "vs": "18845" },
+            "serial_number": { "ts": 1769328781, "vs": "00045875" },
+            "software_version": { "ts": 1769328781, "vs": "2.4.1" },
+            "supported_binding_and_modes": { "ts": 1769328781, "vs": "U" },
+            "utc_offset": { "ts": 1771785563, "vs": "UTC+01:00" }
+          },
+          "_urn": "urn:oma:lwm2m:oma:3:1.1"
+        },
+        "firmware_update": {
+          "0": {
+            "firmware_update_delivery_method": { "vi": 1 },
+            "package_uri": { "vs": "" },
+            "pkg_version": { "vs": "" },
+            "state": { "vi": 0 },
+            "update_result": { "vi": 0 }
+          },
+          "_urn": "urn:oma:lwm2m:oma:5:1.1"
+        },
+        "lemonbeat": {
+          "0": {
+            "ambient_temperature": { "ts": 1771868360, "vi": 20 },
+            "battery_level": { "ts": 1770545566, "vi": 22 },
+            "command": { "ts": 1770223552, "vi": 7 },
+            "error": { "ts": 1769328781, "vi": 0 },
+            "fatal_error_log": { "ts": 1768826104, "vo": "SAAAAJ8MPAG50gIATzgAAP+vAABLKQEATykBAAWaAAA=" },
+            "frost_warning": { "ts": 1769180103, "vi": 0 },
+            "light": { "ts": 1771868360, "vi": 0 },
+            "rf_link_quality": { "ts": 1770500987, "vi": 100 },
+            "soil_humidity": { "ts": 1771866307, "vi": 0 },
+            "soil_humidity_raw_value": { "ts": 1771866307, "vi": 0 },
+            "soil_temperature": { "ts": 1771866307, "vi": 21 }
+          },
+          "_urn": "urn:oma:lwm2m:x:31000"
+        },
+        "lemonbeat_status_message": {
+          "0": {
+            "code": { "ts": 1771785563, "vi": 11 },
+            "data": { "ts": 1771785563, "vs": "" },
+            "level": { "ts": 1771785563, "vi": 1 },
+            "type": { "ts": 1771785563, "vi": 101 }
+          },
+          "_urn": "urn:oma:lwm2m:x:28173"
+        }
+      }
+    },
+    "request_id": "abee8048-f9e0-4c54-8fce-c20ccd5dcf2e",
+    "success": true
+  }
+]

--- a/tests/data/sensor1_update_event.json
+++ b/tests/data/sensor1_update_event.json
@@ -1,0 +1,13 @@
+[
+  {
+    "entity": { "device": "3034F8EE901267400000B333", "path": "lemonbeat/0" },
+    "metadata": { "source": "lemonbeatd", "sequence": 656 },
+    "op": "update",
+    "payload": {
+      "soil_humidity": { "ts": 1771869960, "vi": 0 },
+      "soil_temperature": { "ts": 1771869960, "vi": 21 },
+      "soil_humidity_raw_value": { "ts": 1771869960, "vi": 0 },
+      "_urn": "urn:oma:lwm2m:x:31000"
+    }
+  }
+]

--- a/tests/test_sensor1.py
+++ b/tests/test_sensor1.py
@@ -1,0 +1,72 @@
+import pytest
+
+from gardena_smart_local_api.devices import create_devices_from_messages
+from gardena_smart_local_api.devices.gen1 import Gen1BatteryPoweredGen1Device
+from gardena_smart_local_api.devices.sensors import Sensor1
+
+
+@pytest.mark.asyncio
+async def test_sensor1_is_sensor(sensor1):
+    assert isinstance(sensor1, Sensor1)
+    assert isinstance(sensor1, Gen1BatteryPoweredGen1Device)
+
+
+@pytest.mark.asyncio
+async def test_sensor1_serial_number(sensor1):
+    assert sensor1.serial_number == "00045875"
+
+
+@pytest.mark.asyncio
+async def test_sensor1_is_online(sensor1):
+    assert sensor1.is_online is True
+
+
+@pytest.mark.asyncio
+async def test_sensor1_battery_level(sensor1):
+    battery = sensor1.battery_level
+    assert battery is not None
+    assert isinstance(battery, float)
+    assert 0 <= battery <= 100
+
+
+@pytest.mark.asyncio
+async def test_sensor1_rf_link_quality(sensor1):
+    rf = sensor1.rf_link_quality
+    assert rf is not None
+    assert isinstance(rf, int)
+    assert rf == 100
+
+
+@pytest.mark.asyncio
+async def test_sensor1_temperature(sensor1):
+    temp = sensor1.temperature
+    assert temp is not None
+    assert isinstance(temp, int)
+    assert temp == 20
+
+
+@pytest.mark.asyncio
+async def test_sensor1_light(sensor1):
+    light = sensor1.light
+    assert light is not None
+    assert isinstance(light, int)
+
+
+@pytest.mark.asyncio
+async def test_sensor1_frost_warning(sensor1):
+    frost = sensor1.has_frost_warning
+    assert frost is not None
+    assert isinstance(frost, bool)
+    assert frost is False
+
+
+@pytest.mark.asyncio
+async def test_sensor1_error(sensor1):
+    assert sensor1.error == 0
+
+
+@pytest.mark.asyncio
+async def test_sensor1_update_event(sensor1_and_update_event):
+    devices = await create_devices_from_messages(sensor1_and_update_event)
+    sensor = list(devices.values())[0]
+    assert isinstance(sensor, Sensor1)


### PR DESCRIPTION
- Add model 18845 to device_models.yaml with full lemonbeat object definitions
- Add Sensor class to gen1.py with properties for soil humidity/temperature, ambient temperature, light, frost warning, and error
- Register Sensor in device_builder and export from devices package
- Add examples/sensor.py demonstrating sensor readings