### PR TITLE
Add PowerAdapter device support (model 35279)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Enables controlling and monitoring GARDENA smart devices in the local network, w
 | smart Water Control           | 19033-20                               | 2812               |
 | smart Dual Water Control      | 19034-20                               | 2814               |
 | smart Pipeline Water Control  | 19050-20                               | 2826               |
+| smart Power Adapter           | 19095-20                               | 35279              |
 | smart SILENO                  | 19060-20, 19060-60                     | 6146               |
 | smart SILENO+                 | 19061-20, 19061-60, 19064-60, 19065-60 | 6146               |
 | smart SILENO city             | 19066-20, 19069-20                     | 29694              |

--- a/gardena_smart_local_api/devices/__init__.py
+++ b/gardena_smart_local_api/devices/__init__.py
@@ -5,6 +5,7 @@ from .device_builder import (
 )
 from .irrigation import Gen1WaterControl, Gen2WaterControl
 from .mowers import Gen1Mower1, Gen1Mower2
+from .power import PowerAdapter
 from .sensors import Sensor1, Sensor2
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "Gen1Mower2",
     "Gen1WaterControl",
     "Gen2WaterControl",
+    "PowerAdapter",
     "Sensor1",
     "Sensor2",
     "build_discovery_obj",

--- a/gardena_smart_local_api/devices/device_builder.py
+++ b/gardena_smart_local_api/devices/device_builder.py
@@ -4,6 +4,7 @@ from ..messages import IngressMessageList, Reply
 from .device import Device, DeviceMap
 from .irrigation import Gen1WaterControl, Gen2WaterControl
 from .mowers import Gen1Mower1, Gen1Mower2
+from .power import PowerAdapter
 from .sensors import Sensor1, Sensor2
 
 MODEL_NUMBER_MAP: dict[str, type[Device]] = {
@@ -14,6 +15,7 @@ MODEL_NUMBER_MAP: dict[str, type[Device]] = {
     "2814": Gen2WaterControl,
     "2826": Gen2WaterControl,
     "29694": Gen1Mower1,
+    "35279": PowerAdapter,
     "53988": Gen1Mower2,
     "6146": Gen1Mower1,
 }

--- a/gardena_smart_local_api/devices/gen1.py
+++ b/gardena_smart_local_api/devices/gen1.py
@@ -1,4 +1,4 @@
-from typing import ClassVar
+from typing import ClassVar, Protocol
 
 from pydantic import Field
 
@@ -105,3 +105,13 @@ class Gen1BatteryPoweredDevice(Gen1Device):
 
     def build_refresh_battery_level_obj(self) -> EgressMessageList:
         return self.build_command_obj(self.get_command("measure_battery"))
+
+
+class _Gen1Commands(Protocol):
+    def build_command_obj(self, command: int) -> EgressMessageList: ...
+    def get_command(self, name: str) -> int: ...
+
+
+class IdentifyMixin:
+    def build_identify_obj(self: _Gen1Commands) -> EgressMessageList:
+        return self.build_command_obj(self.get_command("hap_identify"))

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -1,13 +1,13 @@
 from ..messages import EgressMessageList
 from ..resources import IpsoPath
-from .gen1 import Gen1BatteryPoweredDevice
+from .gen1 import Gen1BatteryPoweredDevice, IdentifyMixin
 from .gen2 import Gen2BatteryPoweredDevice
 
 # Used to indicate that the action was initiated through WebSocket API.
 COMMAND_SOURCE = "18"
 
 
-class Gen1WaterControl(Gen1BatteryPoweredDevice):
+class Gen1WaterControl(IdentifyMixin, Gen1BatteryPoweredDevice):
     def build_set_watering_timer_obj(self, seconds: int) -> EgressMessageList:
         """Set the watering timer.
 

--- a/gardena_smart_local_api/devices/power.py
+++ b/gardena_smart_local_api/devices/power.py
@@ -1,0 +1,37 @@
+from ..messages import EgressMessageList
+from ..resources import IpsoPath
+from .gen1 import Gen1Device, IdentifyMixin
+
+
+class PowerAdapter(IdentifyMixin, Gen1Device):
+    @property
+    def power_timer(self) -> int | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="power_timer",
+            )
+        )
+        if isinstance(value, int):
+            return value
+        return None
+
+    @property
+    def is_output_enabled(self) -> bool | None:
+        if (value := self.power_timer) is not None:
+            return value != 0
+        return None
+
+    def build_enable_output_obj(self, seconds: int) -> EgressMessageList:
+        return self.build_write_value_obj(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="power_timer",
+            ),
+            seconds,
+        )
+
+    def build_disable_output_obj(self) -> EgressMessageList:
+        return self.build_enable_output_obj(0)

--- a/gardena_smart_local_api/devices/sensors.py
+++ b/gardena_smart_local_api/devices/sensors.py
@@ -1,9 +1,9 @@
 from ..messages import EgressMessageList
 from ..resources import IpsoPath
-from .gen1 import Gen1BatteryPoweredDevice
+from .gen1 import Gen1BatteryPoweredDevice, IdentifyMixin
 
 
-class _Sensor(Gen1BatteryPoweredDevice):
+class _Sensor(IdentifyMixin, Gen1BatteryPoweredDevice):
     @property
     def has_frost_warning(self) -> bool | None:
         value = self.get_value(

--- a/gardena_smart_local_api/examples/power.py
+++ b/gardena_smart_local_api/examples/power.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import asyncio
+import sys
+
+from gardena_smart_local_api.devices import PowerAdapter
+from gardena_smart_local_api.examples import ExampleApp
+from gardena_smart_local_api.messages import ErrorMessage
+
+COMPATIBLE = (PowerAdapter,)
+
+
+async def main():
+    extra_args = [
+        {
+            "name_or_flags": ["command"],
+            "nargs": 1,
+            "choices": ("list", "on", "off", "identify"),
+            "help": "List applicable devices, identify or turn power on/off",
+        },
+        {
+            "name_or_flags": ["duration"],
+            "nargs": "?",
+            "default": 60,
+            "type": int,
+            "help": "Duration to power on in seconds (default: 60s)",
+        },
+    ]
+
+    async with ExampleApp(extra_args) as app:
+        match app.args.command[0]:
+            case "list":
+                app.list_devices(COMPATIBLE)
+
+            case "on":
+                if app.args.device_id is None:
+                    print("No device ID provided")
+                    return 1
+                pa = app.devices[app.args.device_id]
+                if not isinstance(pa, COMPATIBLE):
+                    print("Incompatible device selected")
+                    return 1
+                request = pa.build_enable_output_obj(app.args.duration)
+                result = await app.send_request(request)
+                if result is not None and not result[0].success:
+                    print("Failed to turn on")
+                    if isinstance(result[0], ErrorMessage):
+                        print(f"Error: {result[0].error_message}")
+                    return 1
+
+            case "off":
+                if app.args.device_id is None:
+                    print("No device ID provided")
+                    return 1
+                pa = app.devices[app.args.device_id]
+                if not isinstance(pa, COMPATIBLE):
+                    print("Incompatible device selected")
+                    return 1
+                request = pa.build_disable_output_obj()
+                result = await app.send_request(request)
+                if result is not None and not result[0].success:
+                    print("Failed to turn off")
+                    if isinstance(result[0], ErrorMessage):
+                        print(f"Error: {result[0].error_message}")
+                    return 1
+
+            case "identify":
+                if app.args.device_id is None:
+                    print("No device ID provided")
+                    return 1
+                pa = app.devices[app.args.device_id]
+                if not isinstance(pa, COMPATIBLE):
+                    print("Incompatible device selected")
+                    return 1
+                request = pa.build_identify_obj()
+                result = await app.send_request(request)
+                if result is not None and not result[0].success:
+                    print("Failed to identify")
+                    if isinstance(result[0], ErrorMessage):
+                        print(f"Error: {result[0].error_message}")
+                    return 1
+
+
+if __name__ == "__main__":
+    rc = asyncio.run(main())
+    sys.exit(rc)

--- a/gardena_smart_local_api/schema/35279_power.yaml
+++ b/gardena_smart_local_api/schema/35279_power.yaml
@@ -1,0 +1,192 @@
+name: smart Power Adapter
+protocol: gen1
+commands:
+  measure_rf_link: 7
+  emc_test_start: 29
+  emc_test_stop: 30
+  reboot: 31
+  ntp_force_sync: 32
+  led_all_off: 33
+  led_all_green_on: 34
+  led_all_red_on: 35
+  hap_identify: 37
+  test_watchdog: 38
+  test_hard_fault: 39
+objects:
+  connection_status:
+    mandatory: true
+    resources:
+      online:
+        type: vb
+        access: r
+        description: Indicates if the device is online (true) or offline (false)
+  device:
+    mandatory: true
+    resources:
+      device_type:
+        type: vs
+        access: r
+        description: Type of the device
+      error_code:
+        type: ai
+        access: r
+        description: Current error code(s)
+      firmware_version:
+        type: vs
+        access: r
+        description: Current firmware version
+      hardware_version:
+        type: vs
+        access: r
+        description: Hardware version
+      manufacturer:
+        type: vs
+        access: r
+        description: Manufacturer name
+      model_number:
+        type: vs
+        access: r
+        description: Model number or identifier
+      serial_number:
+        type: vs
+        access: r
+        description: Serial number
+      software_version:
+        type: vs
+        access: r
+        description: Current software version
+      supported_binding_and_modes:
+        type: vs
+        access: r
+        description: Supported bindings and modes
+      utc_offset:
+        type: vs
+        access: rw
+        description: UTC offset currently in effect for device
+  firmware_update:
+    mandatory: true
+    resources:
+      firmware_update_delivery_method:
+        type: vi
+        access: r
+        description: Firmware update delivery method
+      package_uri:
+        type: vs
+        access: rw
+        description: URI from where the device can download the firmware package
+      pkg_version:
+        type: vs
+        access: r
+        description: Package version
+      state:
+        type: vi
+        access: r
+        min: 0
+        max: 3
+        description: 'Firmware update state: 0=Idle, 1=Downloading, 2=Downloaded, 3=Updating'
+      update_result:
+        type: vi
+        access: r
+        min: 0
+        max: 9
+        description: 'Update result: 0=Initial, 1=Success, 2=Not enough storage, 3=Out of memory, 4=Connection lost, 5=CRC check failure, 6=Unsupported package type, 7=Invalid URI, 8=Update failed, 9=Unsupported protocol'
+  lemonbeat:
+    resources:
+      action_paused_until_1:
+        type: vo
+        access: rw
+        persistent: true
+        encoding: hex
+        report_on_update: true
+        description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
+      command:
+        type: vi
+        access: rw
+        report_on_update: true
+        description: Command to execute
+      error:
+        type: vi
+        access: r
+        report_on_update: true
+        description: Error status (none, timer_cancelled, eeprom)
+      fatal_error_log:
+        type: vo
+        access: r
+        encoding: hex
+        report_on_update: true
+        description: Fatal error log (error identifier, file, line, stack)
+      power_timer:
+        type: vi
+        access: rw
+        unit: s
+        min: -16777215
+        max: 16777216
+        report_on_update: true
+        description: Power timer (write >0=high prio, <0=low prio, 0=stop; read >0=high running, <0=low running, 2^24=infinite on)
+      rf_link_quality:
+        type: vi
+        access: r
+        unit: '%'
+        min: 0
+        max: 100
+        report_on_update: true
+        description: RF link quality percentage
+      schedule_config:
+        type: vo
+        access: r
+        encoding: hex
+        report_on_update: true
+        description: Schedule configuration (read-only, up to 36 schedules)
+      schedule_state:
+        type: vo
+        access: r
+        encoding: hex
+        report_on_update: true
+        description: Schedule state (3 bytes per schedule, 108 bytes total)
+      schedule_state_control_shorten:
+        type: vo
+        access: rw
+        encoding: hex
+        report_on_update: true
+        description: Shorten schedule duration (3 bytes per schedule)
+      schedule_state_control_skip:
+        type: vo
+        access: rw
+        encoding: hex
+        report_on_update: true
+        description: Skip schedule (1 byte per schedule, 36 bytes total)
+      sun_data:
+        type: vo
+        access: rw
+        encoding: hex
+        report_on_update: true
+        description: Sun data for sunrise/sunset calculations (2-byte header + 84 3-byte blocks)
+      sun_schedule_config:
+        type: vo
+        access: rw
+        encoding: hex
+        report_on_update: true
+        description: Sun-based schedule configuration (up to 36 schedules, 7 bytes each)
+  lemonbeat_status_message:
+    mandatory: false
+    resources:
+      code:
+        type: vi
+        access: r
+        description: Status code
+      data:
+        type: vs
+        access: r
+        description: Additional status data (4 bytes HEX)
+      level:
+        type: vi
+        access: r
+        min: 0
+        max: 5
+        description: 'Message level: 0=Disabled, 1=Important, 2=Error, 3=Warning, 4=Info, 5=Debug'
+      type:
+        type: vi
+        access: r
+        min: 0
+        max: 255
+        description: Message type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,3 +133,32 @@ def sensor2_update_event(sensor2_update_event_json):
 @pytest.fixture
 def sensor2_and_update_event(sensor2_message, sensor2_update_event):
     return sensor2_message + sensor2_update_event
+
+
+@pytest.fixture
+def power_adapter_json():
+    data_file = Path(__file__).parent / "data" / "power_adapter.json"
+    with open(data_file) as f:
+        return f.read()
+
+
+@pytest.fixture
+def power_adapter_message(power_adapter_json):
+    return IngressMessageList.model_validate_json(power_adapter_json)
+
+
+@pytest_asyncio.fixture
+async def power_adapter(power_adapter_message):
+    return list((await create_devices_from_messages(power_adapter_message)).values())[0]
+
+
+@pytest.fixture
+def power_adapter_update_event_json():
+    data_file = Path(__file__).parent / "data" / "power_adapter_update_event.json"
+    with open(data_file) as f:
+        return f.read()
+
+
+@pytest.fixture
+def power_adapter_update_event(power_adapter_update_event_json):
+    return IngressMessageList.model_validate_json(power_adapter_update_event_json)

--- a/tests/data/power_adapter.json
+++ b/tests/data/power_adapter.json
@@ -1,0 +1,59 @@
+[
+  {
+    "entity": { "path": "devices", "service": "lemonbeatd" },
+    "metadata": { "sequence": 1434, "source": "lemonbeatd" },
+    "payload": {
+      "3034F8EE902273C000009390": {
+        "connection_status": {
+          "0": { "online": { "ts": 1772100985, "vb": true } },
+          "_urn": "urn:oma:lwm2m:x:28171"
+        },
+        "device": {
+          "0": {
+            "device_type": { "ts": 1770737575, "vs": "Power Adapter" },
+            "error_code": { "ai": [0], "ts": 1770737575 },
+            "firmware_version": { "ts": 1770737575, "vs": "4.0.0-1.5.3" },
+            "hardware_version": { "ts": 1770737575, "vs": "0.0.1" },
+            "manufacturer": { "ts": 1770737575, "vs": "Gardena" },
+            "model_number": { "ts": 1770737575, "vs": "35279" },
+            "serial_number": { "ts": 1770737575, "vs": "00037776" },
+            "software_version": { "ts": 1770737575, "vs": "3.0.3" },
+            "supported_binding_and_modes": { "ts": 1770737575, "vs": "U" },
+            "utc_offset": { "ts": 1774746188, "vs": "UTC+02:00" }
+          },
+          "_urn": "urn:oma:lwm2m:oma:3:1.1"
+        },
+        "firmware_update": {
+          "0": {
+            "firmware_update_delivery_method": { "vi": 1 },
+            "package_uri": { "vs": "" },
+            "pkg_version": { "vs": "" },
+            "state": { "vi": 0 },
+            "update_result": { "vi": 0 }
+          },
+          "_urn": "urn:oma:lwm2m:oma:5:1.1"
+        },
+        "lemonbeat": {
+          "0": {
+            "action_paused_until_1": { "ts": 1769328752, "vo": "" },
+            "be_decision_time": { "ts": 1769328752, "vi": 545 },
+            "command": { "ts": 1774952858, "vi": 37 },
+            "error": { "ts": 1769328752, "vi": 0 },
+            "fatal_error_log": { "ts": 1683703450, "vo": "QQAAH+PC8gDPzgIAw88CAAnPAgBN2QIA56oBAH15AAA=" },
+            "power_timer": { "ts": 1774970116, "vi": 0 },
+            "rf_link_quality": { "ts": 1774967051, "vi": 100 },
+            "schedule_config": { "ts": 1769328752, "vo": "" },
+            "schedule_state": { "ts": 1769328752, "vo": "" },
+            "schedule_state_control_shorten": { "ts": 1769328752, "vo": "" },
+            "schedule_state_control_skip": { "ts": 1769328752, "vo": "" },
+            "sun_data": { "ts": 1769328752, "vo": "XAQPEFnNK1mVr1lcb1oiU1vyulzITl6ewl+AymFp9mNWGmZNPmhK1mpOHm1Yim9qAnJ+unSXhne3znnWinz4bn8fp4FCZ4RnU4eNu4muL4zRs47tV5EEAJQcDJYseJg47JpBwJxD6J5C7KA6XKIuEKQfcKUKiKb2a6fb76fDV6iqX6iOL6h3v6di46ZND6Y/z6Q1N6Mu56Es+58yG54755tKn5lfr5d4K5WTn5K3j5Db340AKIstCIlVOIaAgIOu+IDYfH4FBXwpOXlLhXZtVXSHlXGc6W6skWy0RWq2wWexnWWkoWONnWFzrV9RFV4jnVz2VFvDNFqFoFlNLFk=" },
+            "sun_schedule_config": { "ts": 1769328752, "vo": "" }
+          },
+          "_urn": "urn:oma:lwm2m:x:31000"
+        }
+      }
+    },
+    "request_id": "5f20e8a5-06dd-4745-830a-9c6a8f8e62fc",
+    "success": true
+  }
+]

--- a/tests/data/power_adapter_update_event.json
+++ b/tests/data/power_adapter_update_event.json
@@ -1,0 +1,11 @@
+[
+  {
+    "entity": { "device": "3034F8EE902273C000009390", "path": "lemonbeat/0" },
+    "metadata": { "sequence": 557, "source": "lemonbeatd" },
+    "op": "update",
+    "payload": {
+      "power_timer": { "ts": 1774970419, "vi": 3597 },
+      "_urn": "urn:oma:lwm2m:x:31000"
+    }
+  }
+]

--- a/tests/test_power_adapter.py
+++ b/tests/test_power_adapter.py
@@ -1,0 +1,84 @@
+import pytest
+
+from gardena_smart_local_api.devices.gen1 import Gen1Device
+from gardena_smart_local_api.devices.power import PowerAdapter
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_is_power_adapter(power_adapter):
+    assert isinstance(power_adapter, PowerAdapter)
+    assert isinstance(power_adapter, Gen1Device)
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_serial_number(power_adapter):
+    assert power_adapter.serial_number == "00037776"
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_is_online(power_adapter):
+    assert power_adapter.is_online is True
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_rf_link_quality(power_adapter):
+    rf = power_adapter.rf_link_quality
+    assert rf is not None
+    assert isinstance(rf, int)
+    assert rf == 100
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_power_timer(power_adapter):
+    assert power_adapter.power_timer == 0
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_is_off(power_adapter):
+    assert power_adapter.is_output_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_error(power_adapter):
+    assert power_adapter.error == 0
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_update_event(power_adapter, power_adapter_update_event):
+    event = power_adapter_update_event[0]
+    power_adapter.update_data(event)
+    assert power_adapter.power_timer == 3597
+    assert power_adapter.is_output_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_build_enable_output(power_adapter):
+    request = power_adapter.build_enable_output_obj(120).root[0]
+    assert request.op == "write"
+    assert request.entity.device == power_adapter.id
+    assert request.entity.path.object_name == "lemonbeat"
+    assert request.entity.path.object_instance_id == "0"
+    assert request.entity.path.resource_name == "power_timer"
+    assert request.payload == {"vi": 120}
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_build_disable_output(power_adapter):
+    request = power_adapter.build_disable_output_obj().root[0]
+    assert request.op == "write"
+    assert request.entity.device == power_adapter.id
+    assert request.entity.path.object_name == "lemonbeat"
+    assert request.entity.path.object_instance_id == "0"
+    assert request.entity.path.resource_name == "power_timer"
+    assert request.payload == {"vi": 0}
+
+
+@pytest.mark.asyncio
+async def test_power_adapter_build_identify(power_adapter):
+    request = power_adapter.build_identify_obj().root[0]
+    assert request.op == "write"
+    assert request.entity.device == power_adapter.id
+    assert request.entity.path.object_name == "lemonbeat"
+    assert request.entity.path.object_instance_id == "0"
+    assert request.entity.path.resource_name == "command"
+    assert request.payload == {"vi": 37}


### PR DESCRIPTION
- Add model 35279 schema with full lemonbeat object definitions
- Add `PowerAdapter` device class with `power_timer`, `is_output_enabled`, `error` properties and `build_enable_output_obj`, `build_disable_output_obj`, `build_identify_obj` methods
- Add `IdentifyMixin` to `Gen1WaterControl` and `_Sensor` (covers `Sensor1`, `Sensor2`)
- Register `PowerAdapter` in device builder and export from devices package
- Add `examples/power.py` demonstrating timed power control
- Add tests with real device data