### PR TITLE
Add CI job to enforce commit message/PR style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,11 @@ jobs:
 
       - name: Check installability with latest Home Assistant
         run: uv venv && uv pip install "homeassistant>=2024.12.0" . && uv pip check
+
+  gitlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check commit messages & PR
+        uses: aschbacd/gitlint-action@v1.2.0
+        with:
+          commit-message-subject-max-length: 72


### PR DESCRIPTION
This shall make sure commit messages are formatted in the traditional style, outlined here: https://cbea.ms/git-commit/

Also, as pull request titles will end up in the release changelog, we check them as well.

---

The commit guidelines are documented here: https://github.com/cloudless-garden/gardena-smart-local-api/pull/15