### PR TITLE
Add repository URL to pyproject.toml for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.urls]
+Repository = "https://github.com/cloudless-garden/gardena-smart-local-api"
+
 [dependency-groups]
 dev = [
     "ruff>=0.15.1",


### PR DESCRIPTION
This is in line with:
https://packaging.python.org/en/latest/specifications/well-known-project-urls/

---

Tested here: https://test.pypi.org/project/gardena-smart-local-api/0.0.4.dev1/