### PR TITLE
Add project URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/cloudless-garden/gardena-smart-local-api"
+Homepage = "https://github.com/cloudless-garden/gardena-smart-local-api"
+Issues = "https://github.com/cloudless-garden/gardena-smart-local-api/issues"
+Repository = "https://github.com/cloudless-garden/gardena-smart-local-api.git"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- Adds `[project.urls]` section with `Homepage`, `Issues`, and `Repository` links

## Test plan
- No code changes, metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)