### PR TITLE
Update uv.lock for v0.0.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "gardena-smart-local-api"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
## Summary
- Update `uv.lock` to reflect the v0.0.4 version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)