### PR TITLE
Improve code coverage configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           uv run pytest --cov=gardena_smart_local_api --cov-report=term --cov-report=xml
 
       - name: Coverage comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.12'
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ known-first-party = ["gardena_smart_local_api"]
 [tool.coverage.run]
 relative_files = true
 source = ["gardena_smart_local_api"]
+omit = ["gardena_smart_local_api/examples/*"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
## Summary
- Exclude `gardena_smart_local_api/examples/*` from test coverage reporting
- Fix duplicate coverage comment on PRs by restricting the comment step to one matrix job (race condition when jobs finish simultaneously)

🤖 Generated with [Claude Code](https://claude.com/claude-code)