### PR TITLE
Add support for remaining gen1 mowers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,20 @@ Enables controlling and monitoring GARDENA smart devices in the local network, w
 
 ## Supported Devices
 
-| Device                       | Article Number | Model (EAN suffix) |
-| ---------------------------- | -------------- | ------------------ |
-| smart Sensor                 | 19030-20       | 18845              |
-| smart Sensor II              | 19040-20       | 19040              |
-| smart Water Control          | 19031-20       | 18869              |
-| smart Water Control          | 19033-20       | 2812               |
-| smart Dual Water Control     | 19034-20       | 2814               |
-| smart Pipeline Water Control | 19050-20       | 2826               |
+| Device                        | Article Number                         | Model (EAN suffix) |
+| ----------------------------- | -------------------------------------- | ------------------ |
+| smart Sensor                  | 19030-20                               | 18845              |
+| smart Sensor II               | 19040-20                               | 19040              |
+| smart Water Control           | 19031-20                               | 18869              |
+| smart Water Control           | 19033-20                               | 2812               |
+| smart Dual Water Control      | 19034-20                               | 2814               |
+| smart Pipeline Water Control  | 19050-20                               | 2826               |
+| smart SILENO                  | 19060-20, 19060-60                     | 6146               |
+| smart SILENO+                 | 19061-20, 19061-60, 19064-60, 19065-60 | 6146               |
+| smart SILENO city             | 19066-20, 19069-20                     | 29694              |
+| smart SILENO life             | 19113-20, 19114-20, 19115-20           | 29694              |
+| smart SILENO city (with LONA) | 19602-66, 19603-60, 19605-60           | 53988              |
+| smart SILENO life (with LONA) | 19701-60, 19702-60, 19703-66, 19704-60 | 53988              |
 
 ## Installation
 

--- a/gardena_smart_local_api/devices/__init__.py
+++ b/gardena_smart_local_api/devices/__init__.py
@@ -4,13 +4,14 @@ from .device_builder import (
     create_devices_from_messages,
 )
 from .irrigation import Gen1WaterControl, Gen2WaterControl
-from .mowers import Gen1Mower
+from .mowers import Gen1Mower1, Gen1Mower2
 from .sensors import Sensor1, Sensor2
 
 __all__ = [
     "Device",
     "DeviceMap",
-    "Gen1Mower",
+    "Gen1Mower1",
+    "Gen1Mower2",
     "Gen1WaterControl",
     "Gen2WaterControl",
     "Sensor1",

--- a/gardena_smart_local_api/devices/device_builder.py
+++ b/gardena_smart_local_api/devices/device_builder.py
@@ -3,7 +3,7 @@ from typing import Any
 from ..messages import IngressMessageList, Reply
 from .device import Device, DeviceMap
 from .irrigation import Gen1WaterControl, Gen2WaterControl
-from .mowers import Gen1Mower
+from .mowers import Gen1Mower1, Gen1Mower2
 from .sensors import Sensor1, Sensor2
 
 MODEL_NUMBER_MAP: dict[str, type[Device]] = {
@@ -13,7 +13,9 @@ MODEL_NUMBER_MAP: dict[str, type[Device]] = {
     "2812": Gen2WaterControl,
     "2814": Gen2WaterControl,
     "2826": Gen2WaterControl,
-    "53988": Gen1Mower,
+    "29694": Gen1Mower1,
+    "53988": Gen1Mower2,
+    "6146": Gen1Mower1,
 }
 
 

--- a/gardena_smart_local_api/devices/mowers.py
+++ b/gardena_smart_local_api/devices/mowers.py
@@ -3,34 +3,8 @@ from ..resources import IpsoPath
 from .gen1 import Gen1BatteryPoweredDevice
 
 
-class Gen1Mower(Gen1BatteryPoweredDevice):
-    """
-    For now, only mowers with model number 53988 are supported
-    """
-
-    def build_start_mowing_obj(
-        self, meters_from_cs: int, seconds: int
-    ) -> EgressMessageList:
-        """Start mowing from given starting point, for given duration.
-
-        Args:
-            meters_from_cs: Distance from the charging station in meters
-                            (0: default starting point).
-            seconds: Duration in seconds (0: park until next schedule).
-
-        Returns:
-            EgressMessageList ready to be sent to the local GARDENA smart API.
-        """
-        data = meters_from_cs.to_bytes(2, "big") + seconds.to_bytes(4, "big")
-
-        return self.build_write_value_obj(
-            IpsoPath(
-                object_name="lemonbeat",
-                object_instance_id="0",
-                resource_name="mower_timer_with_distance",
-            ),
-            data,
-        )
+class _Gen1Mower(Gen1BatteryPoweredDevice):
+    """Robotic lawn mower base class"""
 
     def build_stop_mowing_obj(self) -> EgressMessageList:
         """Park until further notice.
@@ -46,6 +20,56 @@ class Gen1Mower(Gen1BatteryPoweredDevice):
                 object_name="lemonbeat",
                 object_instance_id="0",
                 resource_name="action_paused_until_1",
+            ),
+            data,
+        )
+
+
+class Gen1Mower1(_Gen1Mower):
+    """Robotic lawn mower"""
+
+    def build_start_mowing_obj(self, seconds: int) -> EgressMessageList:
+        """Start mowing for given duration.
+
+        Args:
+            seconds: Duration in seconds (0: park until next schedule).
+
+        Returns:
+            EgressMessageList ready to be sent to the local GARDENA smart API.
+        """
+        return self.build_write_value_obj(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="mower_timer",
+            ),
+            seconds,
+        )
+
+
+class Gen1Mower2(_Gen1Mower):
+    """Robotic lawn mower with LONA"""
+
+    def build_start_mowing_obj(
+        self, seconds: int, meters_from_cs: int = 0
+    ) -> EgressMessageList:
+        """Start mowing from given starting point, for given duration.
+
+        Args:
+            seconds: Duration in seconds (0: park until next schedule).
+            meters_from_cs: Distance from the charging station in meters
+                            (0: default starting point).
+
+        Returns:
+            EgressMessageList ready to be sent to the local GARDENA smart API.
+        """
+        data = meters_from_cs.to_bytes(2, "big") + seconds.to_bytes(4, "big")
+
+        return self.build_write_value_obj(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="mower_timer_with_distance",
             ),
             data,
         )

--- a/gardena_smart_local_api/examples/mower.py
+++ b/gardena_smart_local_api/examples/mower.py
@@ -2,7 +2,7 @@
 import asyncio
 import sys
 
-from gardena_smart_local_api.devices import Gen1Mower
+from gardena_smart_local_api.devices import Gen1Mower1, Gen1Mower2
 from gardena_smart_local_api.examples import ExampleApp
 from gardena_smart_local_api.messages import ErrorMessage
 
@@ -35,11 +35,11 @@ async def main():
                     print("No device ID provided")
                     return 1
                 mower = app.devices[app.args.device_id]
-                if not isinstance(mower, Gen1Mower):
+                if not isinstance(mower, (Gen1Mower1, Gen1Mower2)):
                     print("Incompatible device selected")
                     return 1
                 duration = int(app.args.duration * 3600)
-                request = mower.build_start_mowing_obj(0, duration)
+                request = mower.build_start_mowing_obj(duration)
                 result = await app.send_request(request)
                 if result is not None and not result[0].success:
                     print("Failed to start mowing")
@@ -52,7 +52,7 @@ async def main():
                     print("No device ID provided")
                     return 1
                 mower = app.devices[app.args.device_id]
-                if not isinstance(mower, Gen1Mower):
+                if not isinstance(mower, (Gen1Mower1, Gen1Mower2)):
                     print("Incompatible device selected")
                     return 1
                 request = mower.build_stop_mowing_obj()

--- a/gardena_smart_local_api/schema/29694_sileno_city_life.yaml
+++ b/gardena_smart_local_api/schema/29694_sileno_city_life.yaml
@@ -1,0 +1,293 @@
+name: smart SILENO city/life
+type: Robotic lawn mower
+protocol: gen1
+commands:
+  reboot: 31
+  ntp_force_sync: 32
+  led_all_off: 33
+  led_all_green_on: 34
+  led_all_red_on: 35
+  emc_test_start: 29
+  emc_test_stop: 30
+  power_off: 26
+  factory_reset_start_inclusion_mode: 43
+  force_report: 50
+objects:
+  connection_status:
+    object_id: 28171
+    object_urn: urn:oma:lwm2m:ext:28171
+    object_version: '0.2'
+    mandatory: true
+    resources:
+      online:
+        type: vb
+        access: r
+        description: Indicates if the device is online (true) or offline (false)
+  device:
+    object_id: 3
+    object_urn: urn:oma:lwm2m:oma:3
+    object_version: '1.1'
+    mandatory: true
+    resources:
+      device_type:
+        type: vs
+        access: r
+        description: Type of the device
+      error_code:
+        type: ai
+        access: r
+        description: Current error code(s)
+      firmware_version:
+        type: vs
+        access: r
+        description: Current firmware version
+      hardware_version:
+        type: vs
+        access: r
+        description: Hardware version
+      manufacturer:
+        type: vs
+        access: r
+        description: Manufacturer name
+      model_number:
+        type: vs
+        access: r
+        description: Model number or identifier
+      serial_number:
+        type: vs
+        access: r
+        description: Serial number
+      software_version:
+        type: vs
+        access: r
+        description: Current software version
+      supported_binding_and_modes:
+        type: vs
+        access: r
+        description: Supported bindings and modes
+      utc_offset:
+        type: vs
+        access: rw
+        description: UTC offset currently in effect for device
+  firmware_update:
+    object_id: 5
+    object_urn: urn:oma:lwm2m:oma:5
+    object_version: '1.1'
+    mandatory: true
+    resources:
+      firmware_update_delivery_method:
+        type: vi
+        access: r
+        description: Firmware update delivery method
+      package_uri:
+        type: vs
+        access: rw
+        description: URI from where the device can download the firmware package
+      pkg_version:
+        type: vs
+        access: r
+        description: Package version
+      state:
+        type: vi
+        access: r
+        min: 0
+        max: 3
+        description: 'Firmware update state: 0=Idle, 1=Downloading, 2=Downloaded, 3=Updating'
+      update_result:
+        type: vi
+        access: r
+        min: 0
+        max: 9
+        description: 'Update result: 0=Initial, 1=Success, 2=Not enough storage, 3=Out of memory, 4=Connection lost, 5=CRC check failure, 6=Unsupported package type, 7=Invalid URI, 8=Update failed, 9=Unsupported protocol'
+  lemonbeat:
+    resources:
+      action_paused_until_1:
+        type: vo
+        access: rw
+        persistent: true
+        report_on_update: true
+        description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
+      battery_level:
+        type: vi
+        access: r
+        unit: '%'
+        min: 0
+        max: 100
+        report_on_update: true
+        description: Battery level (100% is full)
+      charging_cycles:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Number of completed charging cycles
+      collisions:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Total number of collisions
+      command:
+        type: vi
+        access: rw
+        report_on_update: true
+        description: Command to execute
+      cutting_time:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Time in hours that the cutting disc has been active
+      device_type:
+        type: vs
+        access: r
+        report_on_update: true
+        description: Device type identifier
+      device_variant:
+        type: vs
+        access: r
+        report_on_update: true
+        description: Device variant identifier
+      internal_connection_state:
+        type: vi
+        access: r
+      last_error_code:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Last reported error code from the mower
+      mainboard_version:
+        type: vs
+        access: r
+        report_on_update: true
+        description: 'Mainboard version (format: XX.XX)'
+      manual_operation:
+        type: vi
+        access: r
+        report_on_update: true
+        description: Manual mode status (requires physical access)
+      mmi_version:
+        type: vs
+        access: r
+        report_on_update: true
+        description: 'MMI application version (format: XX.XX)'
+      mower_timer:
+        type: vi
+        access: rw
+        unit: s
+        min: -16777215
+        max: 16777216
+        report_on_update: true
+        description: Manual mowing timer (write >0=start, 0=stop, read >0=running, -16777215=schedule running)
+      rf_link_quality:
+        type: vi
+        access: r
+        unit: '%'
+        min: 0
+        max: 100
+        report_on_update: true
+        description: RF link quality percentage
+      running_time:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Time in hours that the wheel motors have been active
+      schedule_config:
+        type: vo
+        access: rw
+        persistent: true
+        report_on_update: true
+        description: Schedule configuration (up to 14 schedules, 7 bytes each)
+      serial_number:
+        type: vs
+        access: r
+        report_on_update: true
+        description: Mower serial number
+      settings_control:
+        type: vo
+        access: rw
+        persistent: true
+        encoding: hex
+        report_on_update: true
+        description: Write settings (hex encoded custom buffer)
+      settings_report:
+        type: vo
+        access: r
+        encoding: hex
+        report_on_update: true
+        description: Read settings (hex encoded custom buffer)
+      source_for_next_start:
+        type: vi
+        access: r
+        report_on_update: true
+        description: Source/reason for timestamp_next_start (no_source, daily_limit, week_timer, countdown, charging, auto_timer, frost)
+      start_delay_ms:
+        type: vi
+        access: rw
+      starting_points:
+        type: vo
+        access: rw
+        report_on_update: true
+        description: Parameters for three starting points in mower binary format
+      status:
+        type: vi
+        access: r
+        report_on_update: true
+        description: Mower status (off, wait_for_safety, pause, running_mowing_timer, mowing, learning_wire, going_home, charging, error, software_update, wait_leaving_cs, leaving_cs, wait_for_new_task, startup)
+      supported_starting_points:
+        type: vi
+        access: r
+        min: 0
+        max: 3
+        report_on_update: true
+        description: Number of supported starting points
+      supported_wires:
+        type: vi
+        access: r
+        min: 0
+        max: 255
+        report_on_update: true
+        description: Bit mask for supported wire features
+      timestamp_last_error_code:
+        type: vo
+        access: r
+        report_on_update: true
+        description: Timestamp of last error code (seconds since 1970-01-01, local time)
+      timestamp_next_start:
+        type: vo
+        access: r
+        report_on_update: true
+        description: Estimated time of next automatic start (seconds since 1970-01-01, local time, 0=start now)
+  lemonbeat_status_message:
+    object_id: 28173
+    object_urn: urn:oma:lwm2m:ext:28173
+    object_version: '0.1'
+    mandatory: false
+    resources:
+      code:
+        type: vi
+        access: r
+        description: Status code
+      data:
+        type: vs
+        access: r
+        description: Additional status data (4 bytes HEX)
+      level:
+        type: vi
+        access: r
+        min: 0
+        max: 5
+        description: 'Message level: 0=Disabled, 1=Important, 2=Error, 3=Warning, 4=Info, 5=Debug'
+      type:
+        type: vi
+        access: r
+        min: 0
+        max: 255
+        description: Message type

--- a/gardena_smart_local_api/schema/53988_sileno_city_life.yaml
+++ b/gardena_smart_local_api/schema/53988_sileno_city_life.yaml
@@ -1,4 +1,4 @@
-name: SILENO life
+name: SILENO city/life (with LONA)
 protocol: gen1
 commands:
   measure_rf_link: 7
@@ -34,16 +34,16 @@ objects:
     resources:
       checksum:
         type: vi
-        access: null
+        access: r
       content_tag:
         type: vi
-        access: null
+        access: r
       slot:
         type: vi
-        access: null
+        access: r
       status:
         type: vi
-        access: null
+        access: r
   device:
     object_id: 3
     object_urn: urn:oma:lwm2m:oma:3
@@ -164,10 +164,10 @@ objects:
         description: Time in hours that the cutting disc has been active
       data_download:
         type: vo
-        access: null
+        access: r
       data_download_int:
         type: vo
-        access: null
+        access: rw
       device_type:
         type: vs
         access: r
@@ -189,7 +189,7 @@ objects:
         description: Guide wire length in meters
       internal_connection_state:
         type: vi
-        access: null
+        access: r
       last_error_code:
         type: vi
         access: r
@@ -199,7 +199,7 @@ objects:
         description: Last reported error code from the mower
       lona:
         type: vo
-        access: null
+        access: r
       lona_control:
         type:
           - vi
@@ -212,10 +212,10 @@ objects:
         description: LONA control flags (8 bytes, bit flags for LONA features)
       lona_mcu_boot_fw_version:
         type: vo
-        access: null
+        access: r
       lona_mcu_fw_version:
         type: vo
-        access: null
+        access: r
       lona_status:
         type: vo
         access: r
@@ -237,12 +237,9 @@ objects:
         access: r
         report_on_update: true
         description: 'MMI application version (format: XX.XX)'
-      mower_timer:
-        type: vi
-        access: null
       mower_timer_with_distance:
         type: vo
-        access: null
+        access: rw
       position:
         type: vo
         access: r
@@ -313,7 +310,7 @@ objects:
         description: Source/reason for timestamp_next_start (no_source, daily_limit, week_timer, countdown, charging, auto_timer, frost)
       start_delay_ms:
         type: vi
-        access: null
+        access: rw
       starting_points:
         type: vo
         access: rw

--- a/gardena_smart_local_api/schema/6146_sileno.yaml
+++ b/gardena_smart_local_api/schema/6146_sileno.yaml
@@ -1,0 +1,293 @@
+name: smart SILENO(+)
+type: Robotic lawn mower
+protocol: gen1
+commands:
+  reboot: 31
+  ntp_force_sync: 32
+  led_all_off: 33
+  led_all_green_on: 34
+  led_all_red_on: 35
+  emc_test_start: 29
+  emc_test_stop: 30
+  power_off: 26
+  factory_reset_start_inclusion_mode: 43
+  force_report: 50
+objects:
+  connection_status:
+    object_id: 28171
+    object_urn: urn:oma:lwm2m:ext:28171
+    object_version: '0.2'
+    mandatory: true
+    resources:
+      online:
+        type: vb
+        access: r
+        description: Indicates if the device is online (true) or offline (false)
+  device:
+    object_id: 3
+    object_urn: urn:oma:lwm2m:oma:3
+    object_version: '1.1'
+    mandatory: true
+    resources:
+      device_type:
+        type: vs
+        access: r
+        description: Type of the device
+      error_code:
+        type: ai
+        access: r
+        description: Current error code(s)
+      firmware_version:
+        type: vs
+        access: r
+        description: Current firmware version
+      hardware_version:
+        type: vs
+        access: r
+        description: Hardware version
+      manufacturer:
+        type: vs
+        access: r
+        description: Manufacturer name
+      model_number:
+        type: vs
+        access: r
+        description: Model number or identifier
+      serial_number:
+        type: vs
+        access: r
+        description: Serial number
+      software_version:
+        type: vs
+        access: r
+        description: Current software version
+      supported_binding_and_modes:
+        type: vs
+        access: r
+        description: Supported bindings and modes
+      utc_offset:
+        type: vs
+        access: rw
+        description: UTC offset currently in effect for device
+  firmware_update:
+    object_id: 5
+    object_urn: urn:oma:lwm2m:oma:5
+    object_version: '1.1'
+    mandatory: true
+    resources:
+      firmware_update_delivery_method:
+        type: vi
+        access: r
+        description: Firmware update delivery method
+      package_uri:
+        type: vs
+        access: rw
+        description: URI from where the device can download the firmware package
+      pkg_version:
+        type: vs
+        access: r
+        description: Package version
+      state:
+        type: vi
+        access: r
+        min: 0
+        max: 3
+        description: 'Firmware update state: 0=Idle, 1=Downloading, 2=Downloaded, 3=Updating'
+      update_result:
+        type: vi
+        access: r
+        min: 0
+        max: 9
+        description: 'Update result: 0=Initial, 1=Success, 2=Not enough storage, 3=Out of memory, 4=Connection lost, 5=CRC check failure, 6=Unsupported package type, 7=Invalid URI, 8=Update failed, 9=Unsupported protocol'
+  lemonbeat:
+    resources:
+      action_paused_until_1:
+        type: vo
+        access: rw
+        persistent: true
+        report_on_update: true
+        description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
+      battery_level:
+        type: vi
+        access: r
+        unit: '%'
+        min: 0
+        max: 100
+        report_on_update: true
+        description: Battery level (100% is full)
+      charging_cycles:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Number of completed charging cycles
+      collisions:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Total number of collisions
+      command:
+        type: vi
+        access: rw
+        report_on_update: true
+        description: Command to execute
+      cutting_time:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Time in hours that the cutting disc has been active
+      device_type:
+        type: vs
+        access: r
+        report_on_update: true
+        description: Device type identifier
+      device_variant:
+        type: vs
+        access: r
+        report_on_update: true
+        description: Device variant identifier
+      internal_connection_state:
+        type: vi
+        access: r
+      last_error_code:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Last reported error code from the mower
+      mainboard_version:
+        type: vs
+        access: r
+        report_on_update: true
+        description: 'Mainboard version (format: XX.XX)'
+      manual_operation:
+        type: vi
+        access: r
+        report_on_update: true
+        description: Manual mode status (requires physical access)
+      mmi_version:
+        type: vs
+        access: r
+        report_on_update: true
+        description: 'MMI application version (format: XX.XX)'
+      mower_timer:
+        type: vi
+        access: rw
+        unit: s
+        min: -16777215
+        max: 16777216
+        report_on_update: true
+        description: Manual mowing timer (write >0=start, 0=stop, read >0=running, -16777215=schedule running)
+      rf_link_quality:
+        type: vi
+        access: r
+        unit: '%'
+        min: 0
+        max: 100
+        report_on_update: true
+        description: RF link quality percentage
+      running_time:
+        type: vi
+        access: r
+        min: 0
+        max: 65535
+        report_on_update: true
+        description: Time in hours that the wheel motors have been active
+      schedule_config:
+        type: vo
+        access: rw
+        persistent: true
+        report_on_update: true
+        description: Schedule configuration (up to 14 schedules, 7 bytes each)
+      serial_number:
+        type: vs
+        access: r
+        report_on_update: true
+        description: Mower serial number
+      settings_control:
+        type: vo
+        access: rw
+        persistent: true
+        encoding: hex
+        report_on_update: true
+        description: Write settings (hex encoded custom buffer)
+      settings_report:
+        type: vo
+        access: r
+        encoding: hex
+        report_on_update: true
+        description: Read settings (hex encoded custom buffer)
+      source_for_next_start:
+        type: vi
+        access: r
+        report_on_update: true
+        description: Source/reason for timestamp_next_start (no_source, daily_limit, week_timer, countdown, charging, auto_timer, frost)
+      start_delay_ms:
+        type: vi
+        access: rw
+      starting_points:
+        type: vo
+        access: rw
+        report_on_update: true
+        description: Parameters for three starting points in mower binary format
+      status:
+        type: vi
+        access: r
+        report_on_update: true
+        description: Mower status (off, wait_for_safety, pause, running_mowing_timer, mowing, learning_wire, going_home, charging, error, software_update, wait_leaving_cs, leaving_cs, wait_for_new_task, startup)
+      supported_starting_points:
+        type: vi
+        access: r
+        min: 0
+        max: 3
+        report_on_update: true
+        description: Number of supported starting points
+      supported_wires:
+        type: vi
+        access: r
+        min: 0
+        max: 255
+        report_on_update: true
+        description: Bit mask for supported wire features
+      timestamp_last_error_code:
+        type: vo
+        access: r
+        report_on_update: true
+        description: Timestamp of last error code (seconds since 1970-01-01, local time)
+      timestamp_next_start:
+        type: vo
+        access: r
+        report_on_update: true
+        description: Estimated time of next automatic start (seconds since 1970-01-01, local time, 0=start now)
+  lemonbeat_status_message:
+    object_id: 28173
+    object_urn: urn:oma:lwm2m:ext:28173
+    object_version: '0.1'
+    mandatory: false
+    resources:
+      code:
+        type: vi
+        access: r
+        description: Status code
+      data:
+        type: vs
+        access: r
+        description: Additional status data (4 bytes HEX)
+      level:
+        type: vi
+        access: r
+        min: 0
+        max: 5
+        description: 'Message level: 0=Disabled, 1=Important, 2=Error, 3=Warning, 4=Info, 5=Debug'
+      type:
+        type: vi
+        access: r
+        min: 0
+        max: 255
+        description: Message type


### PR DESCRIPTION
Support for smart SILENO(+) and smart SILENO city/life, without the LONA feature, were still missing.

The signature of `Gen1Mower2.build_stop_mowing_obj()` is changed to be more in line with the corresponding `Gen1Mower1` method.

---

Needs testing with older models.

Run the example code as follows:
```
uv run gardena_smart_local_api/examples/mower.py -g $GW -p $PW list
uv run gardena_smart_local_api/examples/mower.py -g $GW -p $PW -d $SGTIN start $DURATION
uv run gardena_smart_local_api/examples/mower.py -g $GW -p $PW -d $SGTIN stop
```