### PR TITLE
Remove type field from device models

### DIFF
--- a/gardena_smart_local_api/devices/device.py
+++ b/gardena_smart_local_api/devices/device.py
@@ -283,8 +283,7 @@ class Device(BaseModel):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(id={self.id!r}, "
-            f"model={self.model_definition.name!r}, "
-            f"type={self.model_definition.type!r})"
+            f"model={self.model_definition.name!r})"
         )
 
 

--- a/gardena_smart_local_api/examples/irrigation.py
+++ b/gardena_smart_local_api/examples/irrigation.py
@@ -28,7 +28,7 @@ async def main():
         match app.args.command[0]:
             case "list":
                 for dev_id, device in app.devices.items():
-                    print(f"{dev_id} ({device.model_definition.type})")
+                    print(f"{dev_id} ({device.model_definition.name})")
 
             case "start":
                 if app.args.device_id is None:

--- a/gardena_smart_local_api/examples/mower.py
+++ b/gardena_smart_local_api/examples/mower.py
@@ -28,7 +28,7 @@ async def main():
         match app.args.command[0]:
             case "list":
                 for dev_id, device in app.devices.items():
-                    print(f"{dev_id} ({device.model_definition.type})")
+                    print(f"{dev_id} ({device.model_definition.name})")
 
             case "start":
                 if app.args.device_id is None:

--- a/gardena_smart_local_api/examples/sensor.py
+++ b/gardena_smart_local_api/examples/sensor.py
@@ -20,7 +20,7 @@ async def main():
         match app.args.command[0]:
             case "list":
                 for dev_id, device in app.devices.items():
-                    print(f"{dev_id} ({device.model_definition.type})")
+                    print(f"{dev_id} ({device.model_definition.name})")
 
             case "read":
                 if app.args.device_id is None:

--- a/gardena_smart_local_api/model_loader.py
+++ b/gardena_smart_local_api/model_loader.py
@@ -11,14 +11,13 @@ DEFAULT_PATH = Path(__file__).parent / "schema" / "device_models.yaml"
 class BaseModelDefinition(BaseModel):
     model_number: str
     name: str
-    type: str
     description: str | None = None
     objects: dict[str, dict[str, Any]] = Field(default_factory=dict)
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(model_number={self.model_number!r}, "
-            f"name={self.name!r}, type={self.type!r})"
+            f"name={self.name!r})"
         )
 
 

--- a/gardena_smart_local_api/schema/device_models.yaml
+++ b/gardena_smart_local_api/schema/device_models.yaml
@@ -11,7 +11,6 @@ types:
 models:
   '18845':
     name: Sensor
-    type: Sensor
     protocol: gen1
     commands:
       measure_soil_moisture: 2
@@ -239,7 +238,6 @@ models:
             description: Message type
   '18869':
     name: Water Control
-    type: Water Control
     protocol: gen1
     commands:
       none: 0
@@ -479,7 +477,6 @@ models:
             description: Message type
   '53988':
     name: SILENO life
-    type: Robotic lawn mower
     protocol: gen1
     commands:
       measure_rf_link: 7

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -19,7 +19,6 @@ async def test_model_loader_get_model_by_number():
     assert model is not None
     assert model.model_number == "18869"
     assert model.name == "Water Control"
-    assert model.type == "Water Control"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Remove the `type` field from `BaseModelDefinition` as the type is reported by the devices themselves and doesn't need to be hardcoded in the YAML schema
- Replace all usages of `model_definition.type` with `model_definition.name` across examples and repr methods
- Remove the corresponding `type` assertions from tests

## Test plan

- [x] All 60 existing tests pass (`uv run pytest`)
- [x] `ruff check`, `ruff format`, and `ty check` all pass