### PR TITLE
Add device inclusion support

### DIFF
--- a/gardena_smart_local_api/devices/__init__.py
+++ b/gardena_smart_local_api/devices/__init__.py
@@ -1,4 +1,4 @@
-from .device import Device, DeviceMap, build_discovery_obj
+from .device import Device, DeviceMap, build_discovery_obj, build_inclusion_obj
 from .device_builder import (
     create_devices_from_json,
     create_devices_from_messages,
@@ -29,6 +29,7 @@ __all__ = [
     "Sensor2",
     "TimeslotState",
     "build_discovery_obj",
+    "build_inclusion_obj",
     "create_devices_from_json",
     "create_devices_from_messages",
 ]

--- a/gardena_smart_local_api/devices/device.py
+++ b/gardena_smart_local_api/devices/device.py
@@ -346,3 +346,21 @@ def build_discovery_obj() -> EgressMessageList:
             ),
         ]
     )
+
+
+def build_inclusion_obj(service: str, instance_id: str) -> EgressMessageList:
+    return EgressMessageList(
+        [
+            Request(
+                op="execute",
+                entity=Entity(
+                    service=service,
+                    path=IpsoPath(
+                        object_name="includable_device",
+                        object_instance_id=instance_id,
+                        resource_name="include",
+                    ),
+                ),
+            )
+        ]
+    )

--- a/gardena_smart_local_api/examples/inclusion.py
+++ b/gardena_smart_local_api/examples/inclusion.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import asyncio
+import sys
+
+from rich import print
+
+from gardena_smart_local_api.devices import build_inclusion_obj
+from gardena_smart_local_api.examples import ExampleApp
+from gardena_smart_local_api.messages import Reply
+from gardena_smart_local_api.sgtin96 import parse_sgtin96
+
+
+async def prompt(question: str) -> str:
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, input, question)
+
+
+async def main():
+    async with ExampleApp(()) as app:
+        seen: set[str] = set()
+
+        print("Listening for includable devices...")
+        while True:
+            if not app.events:
+                await asyncio.sleep(0.1)
+                continue
+            event = app.events.pop(0)
+            if event.entity.path.object_name != "includable_device":
+                continue
+
+            instance_id = event.entity.path.object_instance_id
+            if instance_id in seen:
+                continue
+            seen.add(instance_id)
+
+            device_id = event.payload.get("identifier", {}).get("vs", instance_id)
+            try:
+                info = parse_sgtin96(device_id)
+                name = await info.get_model_name()
+                device_desc = f"[bold]{name} {info.serial:08d}[/bold]"
+            except ValueError:
+                device_desc = device_id
+            print(f"Found includable device: {device_desc}")
+            answer = await prompt("Include? [y/N] ")
+            if answer.strip().lower() != "y":
+                continue
+
+            replies = await app.send_request(
+                build_inclusion_obj(event.entity.service, instance_id)
+            )
+            if replies and isinstance(replies[0], Reply) and replies[0].success:
+                print(f"[green]Device {device_desc} included successfully.[/green]")
+                return 0
+            else:
+                print(f"[red]Inclusion of {device_desc} failed.[/red]")
+                return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/gardena_smart_local_api/sgtin96.py
+++ b/gardena_smart_local_api/sgtin96.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+from gardena_smart_local_api.model_loader import get_model_loader
+
+_PARTITION_TABLE = {
+    0: (40, 12, 4, 1),
+    1: (37, 11, 7, 2),
+    2: (34, 10, 10, 3),
+    3: (30, 9, 14, 4),
+    4: (27, 8, 17, 5),
+    5: (24, 7, 20, 6),
+    6: (20, 6, 24, 7),
+}
+
+
+def _gtin_checksum(digits: str) -> str:
+    total = sum(
+        int(d) * (3 if i % 2 == 0 else 1) for i, d in enumerate(reversed(digits))
+    )
+    remainder = total % 10
+    return "0" if remainder == 0 else str(10 - remainder)
+
+
+@dataclass
+class Sgtin96Info:
+    serial: int
+    gtin13: str
+    company_prefix: str
+    item_reference: str
+    check_digit: str
+
+    async def get_model_name(self) -> str:
+        loader = await get_model_loader()
+        model = loader.get_model(self.item_reference)
+        return model.name if model else self.item_reference
+
+
+def parse_sgtin96(hex_str: str) -> Sgtin96Info:
+    if len(hex_str) != 24:
+        raise ValueError("SGTIN96 must be 24 hex characters")
+    bits = f"{int(hex_str, 16):096b}"
+    if bits[:8] != "00110000":
+        raise ValueError("Not a valid SGTIN96 (invalid header)")
+    partition = int(bits[11:14], 2)
+    company_bits, company_digits, _, item_digits = _PARTITION_TABLE[partition]
+    company = str(int(bits[14 : 14 + company_bits], 2)).zfill(company_digits)
+    item_and_indicator = str(int(bits[14 + company_bits : 58], 2)).zfill(item_digits)
+    item_padded = item_and_indicator[1:]
+    item = item_padded.lstrip("0") or "0"
+    check = _gtin_checksum(company + item_padded)
+    serial = int(bits[58:96], 2)
+    gtin13 = company + item_padded + check
+    return Sgtin96Info(
+        serial=serial,
+        gtin13=gtin13,
+        company_prefix=company,
+        item_reference=item,
+        check_digit=check,
+    )

--- a/tests/test_sgtin96.py
+++ b/tests/test_sgtin96.py
@@ -1,0 +1,67 @@
+import pytest
+
+from gardena_smart_local_api.sgtin96 import Sgtin96Info, parse_sgtin96
+
+PARSE_CASES = pytest.mark.parametrize(
+    "hex_str, expected",
+    [
+        pytest.param(
+            "3034F8EE901267400000B333",
+            Sgtin96Info(
+                serial=45875,
+                company_prefix="4078500",
+                item_reference="18845",
+                check_digit="6",
+                gtin13="4078500188456",
+            ),
+            id="sensor1",
+        ),
+        pytest.param(
+            "3034F8319C0075400000010A",
+            Sgtin96Info(
+                serial=266,
+                company_prefix="4066407",
+                item_reference="469",
+                check_digit="6",
+                gtin13="4066407004696",
+            ),
+            id="irrigation_control",
+        ),
+    ],
+)
+
+
+@PARSE_CASES
+def test_parse_sgtin96(hex_str, expected):
+    assert parse_sgtin96(hex_str) == expected
+
+
+@PARSE_CASES
+def test_parse_sgtin96_lowercase(hex_str, expected):
+    assert parse_sgtin96(hex_str.lower()) == expected
+
+
+@pytest.mark.parametrize(
+    "hex_str, model_name",
+    [
+        pytest.param("3034F8EE901267400000B333", "smart Sensor", id="sensor1"),
+        pytest.param(
+            "3034F8319C0075400000010A",
+            "smart Irrigation Control",
+            id="irrigation_control",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_parse_sgtin96_model_name(hex_str, model_name):
+    assert await parse_sgtin96(hex_str).get_model_name() == model_name
+
+
+def test_parse_sgtin96_invalid_length():
+    with pytest.raises(ValueError, match="24 hex characters"):
+        parse_sgtin96("3034F8EE")
+
+
+def test_parse_sgtin96_invalid_header():
+    with pytest.raises(ValueError, match="invalid header"):
+        parse_sgtin96("FF34F8EE901267400000B333")


### PR DESCRIPTION
## Summary
- Add `build_include_obj` to build an execute request from an includable_device event
- Add `include.py` example script that listens for includable devices and prompts the user to include them

## Test plan
- [ ] Run `python -m gardena_smart_local_api.examples.include -g <gateway> -p <password>` and verify a nearby device can be included interactively