### PR TITLE
Fix blocking scandir call in async event loop

### DIFF
--- a/gardena_smart_local_api/model_loader.py
+++ b/gardena_smart_local_api/model_loader.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from typing import Any, Literal
 
@@ -60,7 +61,10 @@ class ModelLoader:
         if self._loaded:
             return
 
-        for model_file in sorted(self.schema_dir.glob("*.yaml")):
+        model_files = await asyncio.to_thread(
+            lambda: sorted(self.schema_dir.glob("*.yaml"))
+        )
+        for model_file in model_files:
             model_number = model_file.stem.split("_")[0]
             async with async_open(model_file, mode="r") as f:
                 data = yaml.safe_load(await f.read())


### PR DESCRIPTION
## Summary

- `ModelLoader.load()` called `Path.glob()` synchronously, which triggers `os.scandir` and blocks the Home Assistant event loop
- Wrapped the glob call in `asyncio.to_thread()` to offload it to a thread pool executor

## Test plan

- [ ] Deploy to Home Assistant and confirm the blocking call warning no longer appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)