### PR TITLE
Remove unnecessary fields from model definitions

### DIFF
--- a/gardena_smart_local_api/resources.py
+++ b/gardena_smart_local_api/resources.py
@@ -238,10 +238,6 @@ class IpsoObject:
     ):
         self.name = name
         self.object_instance_id = object_instance_id
-        self.object_id = object_data.get("object_id")
-        self.object_urn = object_data.get("object_urn")
-        self.object_version = object_data.get("object_version")
-        self.mandatory = object_data.get("mandatory", False)
         self.multi_instance = object_data.get("multi_instance", False)
 
         self.resources: dict[str, IpsoResource] = {}

--- a/gardena_smart_local_api/schema/18845_sensor1.yaml
+++ b/gardena_smart_local_api/schema/18845_sensor1.yaml
@@ -19,14 +19,12 @@ commands:
   test_hard_fault: 39
 objects:
   connection_status:
-    mandatory: true
     resources:
       online:
         type: vb
         access: r
         description: Indicates if the device is online (true) or offline (false)
   device:
-    mandatory: true
     resources:
       device_type:
         type: vs
@@ -69,7 +67,6 @@ objects:
         access: rw
         description: UTC offset currently in effect for device
   firmware_update:
-    mandatory: true
     resources:
       firmware_update_delivery_method:
         type: vi
@@ -103,8 +100,6 @@ objects:
         unit: C
         min: -30
         max: 85
-        report_on_update: true
-        report_interval: 3600
         description: Ambient temperature (not currently used)
       battery_level:
         type: vi
@@ -112,30 +107,24 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: Battery level (100% is full)
       command:
         type: vi
         access: rw
-        report_on_update: true
         description: Command to execute
       error:
         type: vi
         access: r
-        report_on_update: true
         description: Error status (none, eeprom, brown_out)
       fatal_error_log:
         type: vo
         access: r
-        report_on_update: true
         description: Fatal error log
       frost_warning:
         type: vi
         access: r
         min: 0
         max: 1
-        report_on_update: true
-        report_interval: 3600
         description: Frost warning if temperature falls below +5°C (1=frost, 0=no frost)
       light:
         type: vi
@@ -143,8 +132,6 @@ objects:
         unit: lx
         min: 0
         max: 200000
-        report_on_update: true
-        report_interval: 3600
         description: Light intensity in lux
       rf_link_quality:
         type: vi
@@ -152,7 +139,6 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: RF link quality percentage
       soil_humidity:
         type: vi
@@ -160,8 +146,6 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
-        report_interval: 14400
         description: Soil moisture value (mean weighted)
       soil_humidity_raw_value:
         type: vi
@@ -169,8 +153,6 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
-        report_interval: 14400
         description: Soil moisture value as measured
       soil_temperature:
         type: vi
@@ -178,11 +160,8 @@ objects:
         unit: C
         min: -30
         max: 85
-        report_on_update: true
-        report_interval: 3600
         description: Ground temperature
   lemonbeat_status_message:
-    mandatory: false
     resources:
       code:
         type: vi

--- a/gardena_smart_local_api/schema/18869_water_control.yaml
+++ b/gardena_smart_local_api/schema/18869_water_control.yaml
@@ -18,14 +18,12 @@ commands:
   test_hard_fault: 39
 objects:
   connection_status:
-    mandatory: true
     resources:
       online:
         type: vb
         access: r
         description: Indicates if the device is online (true) or offline (false)
   device:
-    mandatory: true
     resources:
       device_type:
         type: vs
@@ -68,7 +66,6 @@ objects:
         access: rw
         description: UTC offset currently in effect for device
   firmware_update:
-    mandatory: true
     resources:
       firmware_update_delivery_method:
         type: vi
@@ -99,9 +96,7 @@ objects:
       action_paused_until_1:
         type: vo
         access: rw
-        persistent: true
         encoding: hex
-        report_on_update: true
         description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
       ambient_temperature:
         type: vi
@@ -109,8 +104,6 @@ objects:
         unit: C
         min: -30
         max: 85
-        report_on_update: true
-        report_interval: 3600
         description: Ambient temperature
       battery_level:
         type: vi
@@ -118,8 +111,6 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
-        report_interval: 86400
         description: Battery level measured when switching the valve
       button_config_time:
         type: vi
@@ -127,32 +118,25 @@ objects:
         unit: s
         min: 0
         max: 36000
-        persistent: true
-        report_on_update: true
         description: Valve open time after button press (default 30 minutes)
       command:
         type: vi
         access: rw
-        report_on_update: true
         description: Command to execute
       error:
         type: vi
         access: r
-        report_on_update: true
         description: Error status (none, eeprom, brown_out)
       fatal_error_log:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Fatal error log (error identifier, file, line, stack)
       frost_warning:
         type: vi
         access: r
         min: 0
         max: 1
-        report_on_update: true
-        report_interval: 3600
         description: Frost warning if temperature falls below +5°C (1=frost, 0=no frost)
       rf_link_quality:
         type: vi
@@ -160,37 +144,30 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: RF link quality percentage
       schedule_config:
         type: vo
         access: rw
         encoding: hex
-        persistent: true
-        report_on_update: true
         description: Schedule configuration (up to 36 schedules, 7 bytes each)
       schedule_state:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Schedule state (3 bytes per schedule, 108 bytes total)
       schedule_state_control_shorten:
         type: vo
         access: rw
         encoding: hex
-        report_on_update: true
         description: Shorten schedule duration (3 bytes per schedule)
       schedule_state_control_skip:
         type: vo
         access: rw
         encoding: hex
-        report_on_update: true
         description: Skip schedule (1 byte per schedule, 36 bytes total)
       valve_error_1:
         type: vi
         access: r
-        report_on_update: true
         description: Valve error status (none, valve_broken, frost_prevents_starting, low_battery_prevents_starting, valve_power_supply_failed)
       watering_timer_1:
         type: vi
@@ -198,10 +175,8 @@ objects:
         unit: s
         min: -36000
         max: 36000
-        report_on_update: true
         description: Watering timer (write >0=start manual, <0=start scheduled, 0=stop; read 0=not running, >0=manual running, <0=scheduled running)
   lemonbeat_status_message:
-    mandatory: false
     resources:
       code:
         type: vi

--- a/gardena_smart_local_api/schema/19040_sensor2.yaml
+++ b/gardena_smart_local_api/schema/19040_sensor2.yaml
@@ -20,14 +20,12 @@ commands:
   force_report: 50
 objects:
   connection_status:
-    mandatory: true
     resources:
       online:
         type: vb
         access: r
         description: Indicates if the device is online (true) or offline (false)
   device:
-    mandatory: true
     resources:
       device_type:
         type: vs
@@ -70,7 +68,6 @@ objects:
         access: rw
         description: UTC offset currently in effect for device
   firmware_update:
-    mandatory: true
     resources:
       firmware_update_delivery_method:
         type: vi
@@ -102,7 +99,6 @@ objects:
         type: vo
         access: rw
         encoding: hex
-        report_on_update: true
         description: Soil auto-recognition internal state (saved/restored after firmware upgrade)
       battery_level:
         type: vi
@@ -110,37 +106,30 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: Battery level (100% is full)
       command:
         type: vi
         access: rw
-        report_on_update: true
         description: Command to execute
       error:
         type: vi
         access: r
-        report_on_update: true
         description: Sensor error status (none, eeprom)
       experimental_model_state:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Experimental model internal state
       fatal_error_log:
         type: vo
         access: r
-        report_on_update: true
         description: Fatal error log
       frost_warning:
         type: vi
         access: r
         min: 0
         max: 1
-        report_on_update: true
-        report_interval: 3600
         description: Frost warning if temperature falls below +5°C (1=frost, 0=no frost)
       measurement_interval:
         type: vi
@@ -148,8 +137,6 @@ objects:
         unit: s
         min: 10
         max: 86400
-        persistent: true
-        report_on_update: true
         description: Time interval between periodic measurements when model is final
       model_definition:
         type: vo
@@ -159,14 +146,10 @@ objects:
       model_determination_mode:
         type: vi
         access: rw
-        persistent: true
-        report_on_update: true
         description: Soil recognition logic mode (default or experimental)
       model_determination_status:
         type: vi
         access: rw
-        persistent: true
-        report_on_update: true
         description: Model determination status (default_model, determination_running, preliminary_model, final_model, determination_failed, power_up, location_change)
       raw_counts:
         type: vi
@@ -174,7 +157,6 @@ objects:
         unit: Counts
         min: 0
         max: 10000
-        report_on_update: true
         description: Raw counter values
       rf_link_quality:
         type: vi
@@ -182,7 +164,6 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: RF link quality percentage
       soil_moisture:
         type: vi
@@ -190,8 +171,6 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
-        report_interval: 3600
         description: Soil moisture percentage
       soil_moisture_experimental_model:
         type: vi
@@ -199,8 +178,6 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
-        report_interval: 900
         description: Soil moisture from experimental model
       soil_temperature:
         type: vi
@@ -208,29 +185,23 @@ objects:
         unit: C
         min: -30
         max: 85
-        report_on_update: true
-        report_interval: 3600
         description: Near ground or soil temperature
       soil_type_determination_result_1:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: First 100 measurements as raw counts (8h 20min)
       soil_type_determination_result_2:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Next 100 measurements as raw counts (8h 20min)
       soil_type_determination_result_3:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Last 88 measurements as raw counts (7h 20min)
   lemonbeat_status_message:
-    mandatory: false
     resources:
       code:
         type: vi

--- a/gardena_smart_local_api/schema/2812_water_control.yaml
+++ b/gardena_smart_local_api/schema/2812_water_control.yaml
@@ -2,10 +2,6 @@ name: smart Water Control
 protocol: gen2
 objects:
   actuator:
-    object_id: 28180
-    object_urn: urn:oma:lwm2m:x:28180:0.4
-    object_version: '0.4'
-    mandatory: false
     multi_instance: true
     resources:
       default_duration_seconds:
@@ -60,10 +56,6 @@ objects:
         access: x
         description: Reset actuator error.
   connection_status:
-    object_id: 28171
-    object_urn: urn:oma:lwm2m:x:28171
-    object_version: '1.0'
-    mandatory: false
     resources:
       online:
         type: vb
@@ -169,18 +161,12 @@ objects:
         type: vi
         access: r
   irrigation_control:
-    object_id: 28152
-    object_urn: urn:oma:lwm2m:x:28152:0.2
-    object_version: '0.2'
     resources:
       error:
         type: vi
         access: r
         description: Device error
   master_channel:
-    object_id: 30000
-    object_urn: urn:oma:lwm2m:x:30000:0.1
-    object_version: '0.1'
     multi_instance: true
     resources:
       available:
@@ -201,9 +187,6 @@ objects:
         unit: s
         description: Default time is 20 s
   schedule:
-    object_id: 28181
-    object_urn: urn:oma:lwm2m:x:28181:0.2
-    object_version: '0.2'
     multi_instance: true
     resources:
       start_offset_from:
@@ -241,9 +224,6 @@ objects:
         access: rw
         description: Magic cookie used by backend. Copied over to corresponding timeslot.
   sg_common:
-    object_id: 28183
-    object_urn: urn:oma:lwm2m:x:28183:0.6
-    object_version: '0.6'
     resources:
       be_decision_seconds:
         type: vi
@@ -326,9 +306,6 @@ objects:
         access: x
         description: Request the device to send all ipso objects.
   timeslot:
-    object_id: 28182
-    object_urn: urn:oma:lwm2m:x:28182:0.2
-    object_version: '0.2'
     multi_instance: true
     resources:
       start:

--- a/gardena_smart_local_api/schema/2814_water_control_duo.yaml
+++ b/gardena_smart_local_api/schema/2814_water_control_duo.yaml
@@ -2,10 +2,6 @@ name: smart Dual Water Control
 protocol: gen2
 objects:
   actuator:
-    object_id: 28180
-    object_urn: urn:oma:lwm2m:x:28180:0.4
-    object_version: '0.4'
-    mandatory: false
     multi_instance: true
     resources:
       default_duration_seconds:
@@ -60,10 +56,6 @@ objects:
         access: x
         description: Reset actuator error.
   connection_status:
-    object_id: 28171
-    object_urn: urn:oma:lwm2m:x:28171
-    object_version: '1.0'
-    mandatory: false
     resources:
       online:
         type: vb
@@ -169,18 +161,12 @@ objects:
         type: vi
         access: r
   irrigation_control:
-    object_id: 28152
-    object_urn: urn:oma:lwm2m:x:28152:0.2
-    object_version: '0.2'
     resources:
       error:
         type: vi
         access: r
         description: Device error
   master_channel:
-    object_id: 30000
-    object_urn: urn:oma:lwm2m:x:30000:0.1
-    object_version: '0.1'
     multi_instance: true
     resources:
       available:
@@ -201,9 +187,6 @@ objects:
         unit: s
         description: Default time is 20 s
   schedule:
-    object_id: 28181
-    object_urn: urn:oma:lwm2m:x:28181:0.2
-    object_version: '0.2'
     multi_instance: true
     resources:
       start_offset_from:
@@ -241,9 +224,6 @@ objects:
         access: rw
         description: Magic cookie used by backend. Copied over to corresponding timeslot.
   sg_common:
-    object_id: 28183
-    object_urn: urn:oma:lwm2m:x:28183:0.6
-    object_version: '0.6'
     resources:
       be_decision_seconds:
         type: vi
@@ -326,9 +306,6 @@ objects:
         access: x
         description: Request the device to send all ipso objects.
   timeslot:
-    object_id: 28182
-    object_urn: urn:oma:lwm2m:x:28182:0.2
-    object_version: '0.2'
     multi_instance: true
     resources:
       start:

--- a/gardena_smart_local_api/schema/2826_pipeline_water_control.yaml
+++ b/gardena_smart_local_api/schema/2826_pipeline_water_control.yaml
@@ -2,10 +2,6 @@ name: smart Pipeline Water Control
 protocol: gen2
 objects:
   actuator:
-    object_id: 28180
-    object_urn: urn:oma:lwm2m:x:28180:0.4
-    object_version: '0.4'
-    mandatory: false
     multi_instance: true
     resources:
       default_duration_seconds:
@@ -60,10 +56,6 @@ objects:
         access: x
         description: Reset actuator error.
   connection_status:
-    object_id: 28171
-    object_urn: urn:oma:lwm2m:x:28171
-    object_version: '1.0'
-    mandatory: false
     resources:
       online:
         type: vb
@@ -169,18 +161,12 @@ objects:
         type: vi
         access: r
   irrigation_control:
-    object_id: 28152
-    object_urn: urn:oma:lwm2m:x:28152:0.2
-    object_version: '0.2'
     resources:
       error:
         type: vi
         access: r
         description: Device error
   master_channel:
-    object_id: 30000
-    object_urn: urn:oma:lwm2m:x:30000:0.1
-    object_version: '0.1'
     multi_instance: true
     resources:
       available:
@@ -201,9 +187,6 @@ objects:
         unit: s
         description: Default time is 20 s
   schedule:
-    object_id: 28181
-    object_urn: urn:oma:lwm2m:x:28181:0.2
-    object_version: '0.2'
     multi_instance: true
     resources:
       start_offset_from:
@@ -241,9 +224,6 @@ objects:
         access: rw
         description: Magic cookie used by backend. Copied over to corresponding timeslot.
   sg_common:
-    object_id: 28183
-    object_urn: urn:oma:lwm2m:x:28183:0.6
-    object_version: '0.6'
     resources:
       be_decision_seconds:
         type: vi
@@ -326,9 +306,6 @@ objects:
         access: x
         description: Request the device to send all ipso objects.
   timeslot:
-    object_id: 28182
-    object_urn: urn:oma:lwm2m:x:28182:0.2
-    object_version: '0.2'
     multi_instance: true
     resources:
       start:

--- a/gardena_smart_local_api/schema/29694_sileno_city_life.yaml
+++ b/gardena_smart_local_api/schema/29694_sileno_city_life.yaml
@@ -10,20 +10,12 @@ commands:
   factory_reset_start_inclusion_mode: 43
 objects:
   connection_status:
-    object_id: 28171
-    object_urn: urn:oma:lwm2m:ext:28171
-    object_version: '0.2'
-    mandatory: true
     resources:
       online:
         type: vb
         access: r
         description: Indicates if the device is online (true) or offline (false)
   device:
-    object_id: 3
-    object_urn: urn:oma:lwm2m:oma:3
-    object_version: '1.1'
-    mandatory: true
     resources:
       device_type:
         type: vs
@@ -66,10 +58,6 @@ objects:
         access: rw
         description: UTC offset currently in effect for device
   firmware_update:
-    object_id: 5
-    object_urn: urn:oma:lwm2m:oma:5
-    object_version: '1.1'
-    mandatory: true
     resources:
       firmware_update_delivery_method:
         type: vi
@@ -100,8 +88,6 @@ objects:
       action_paused_until_1:
         type: vo
         access: rw
-        persistent: true
-        report_on_update: true
         description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
       battery_level:
         type: vi
@@ -109,43 +95,36 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: Battery level (100% is full)
       charging_cycles:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Number of completed charging cycles
       collisions:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Total number of collisions
       command:
         type: vi
         access: rw
-        report_on_update: true
         description: Command to execute
       cutting_time:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Time in hours that the cutting disc has been active
       device_type:
         type: vs
         access: r
-        report_on_update: true
         description: Device type identifier
       device_variant:
         type: vs
         access: r
-        report_on_update: true
         description: Device variant identifier
       internal_connection_state:
         type: vi
@@ -155,22 +134,18 @@ objects:
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Last reported error code from the mower
       mainboard_version:
         type: vs
         access: r
-        report_on_update: true
         description: 'Mainboard version (format: XX.XX)'
       manual_operation:
         type: vi
         access: r
-        report_on_update: true
         description: Manual mode status (requires physical access)
       mmi_version:
         type: vs
         access: r
-        report_on_update: true
         description: 'MMI application version (format: XX.XX)'
       mower_timer:
         type: vi
@@ -178,7 +153,6 @@ objects:
         unit: s
         min: -16777215
         max: 16777216
-        report_on_update: true
         description: Manual mowing timer (write >0=start, 0=stop, read >0=running, -16777215=schedule running)
       rf_link_quality:
         type: vi
@@ -186,43 +160,34 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: RF link quality percentage
       running_time:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Time in hours that the wheel motors have been active
       schedule_config:
         type: vo
         access: rw
-        persistent: true
-        report_on_update: true
         description: Schedule configuration (up to 14 schedules, 7 bytes each)
       serial_number:
         type: vs
         access: r
-        report_on_update: true
         description: Mower serial number
       settings_control:
         type: vo
         access: rw
-        persistent: true
         encoding: hex
-        report_on_update: true
         description: Write settings (hex encoded custom buffer)
       settings_report:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Read settings (hex encoded custom buffer)
       source_for_next_start:
         type: vi
         access: r
-        report_on_update: true
         description: Source/reason for timestamp_next_start (no_source, daily_limit, week_timer, countdown, charging, auto_timer, frost)
       start_delay_ms:
         type: vi
@@ -230,42 +195,32 @@ objects:
       starting_points:
         type: vo
         access: rw
-        report_on_update: true
         description: Parameters for three starting points in mower binary format
       status:
         type: vi
         access: r
-        report_on_update: true
         description: Mower status (off, wait_for_safety, pause, running_mowing_timer, mowing, learning_wire, going_home, charging, error, software_update, wait_leaving_cs, leaving_cs, wait_for_new_task, startup)
       supported_starting_points:
         type: vi
         access: r
         min: 0
         max: 3
-        report_on_update: true
         description: Number of supported starting points
       supported_wires:
         type: vi
         access: r
         min: 0
         max: 255
-        report_on_update: true
         description: Bit mask for supported wire features
       timestamp_last_error_code:
         type: vo
         access: r
-        report_on_update: true
         description: Timestamp of last error code (seconds since 1970-01-01, local time)
       timestamp_next_start:
         type: vo
         access: r
-        report_on_update: true
         description: Estimated time of next automatic start (seconds since 1970-01-01, local time, 0=start now)
   lemonbeat_status_message:
-    object_id: 28173
-    object_urn: urn:oma:lwm2m:ext:28173
-    object_version: '0.1'
-    mandatory: false
     resources:
       code:
         type: vi

--- a/gardena_smart_local_api/schema/35279_power.yaml
+++ b/gardena_smart_local_api/schema/35279_power.yaml
@@ -14,14 +14,12 @@ commands:
   test_hard_fault: 39
 objects:
   connection_status:
-    mandatory: true
     resources:
       online:
         type: vb
         access: r
         description: Indicates if the device is online (true) or offline (false)
   device:
-    mandatory: true
     resources:
       device_type:
         type: vs
@@ -64,7 +62,6 @@ objects:
         access: rw
         description: UTC offset currently in effect for device
   firmware_update:
-    mandatory: true
     resources:
       firmware_update_delivery_method:
         type: vi
@@ -95,25 +92,20 @@ objects:
       action_paused_until_1:
         type: vo
         access: rw
-        persistent: true
         encoding: hex
-        report_on_update: true
         description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
       command:
         type: vi
         access: rw
-        report_on_update: true
         description: Command to execute
       error:
         type: vi
         access: r
-        report_on_update: true
         description: Error status (none, timer_cancelled, eeprom)
       fatal_error_log:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Fatal error log (error identifier, file, line, stack)
       power_timer:
         type: vi
@@ -121,7 +113,6 @@ objects:
         unit: s
         min: -16777215
         max: 16777216
-        report_on_update: true
         description: Power timer (write >0=high prio, <0=low prio, 0=stop; read >0=high running, <0=low running, 2^24=infinite on)
       rf_link_quality:
         type: vi
@@ -129,46 +120,38 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: RF link quality percentage
       schedule_config:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Schedule configuration (read-only, up to 36 schedules)
       schedule_state:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Schedule state (3 bytes per schedule, 108 bytes total)
       schedule_state_control_shorten:
         type: vo
         access: rw
         encoding: hex
-        report_on_update: true
         description: Shorten schedule duration (3 bytes per schedule)
       schedule_state_control_skip:
         type: vo
         access: rw
         encoding: hex
-        report_on_update: true
         description: Skip schedule (1 byte per schedule, 36 bytes total)
       sun_data:
         type: vo
         access: rw
         encoding: hex
-        report_on_update: true
         description: Sun data for sunrise/sunset calculations (2-byte header + 84 3-byte blocks)
       sun_schedule_config:
         type: vo
         access: rw
         encoding: hex
-        report_on_update: true
         description: Sun-based schedule configuration (up to 36 schedules, 7 bytes each)
   lemonbeat_status_message:
-    mandatory: false
     resources:
       code:
         type: vi

--- a/gardena_smart_local_api/schema/53988_sileno_city_life.yaml
+++ b/gardena_smart_local_api/schema/53988_sileno_city_life.yaml
@@ -17,10 +17,6 @@ commands:
   trigger_guide_wire_length_measurement: 51
 objects:
   connection_status:
-    object_id: 28171
-    object_urn: urn:oma:lwm2m:ext:28171
-    object_version: '0.2'
-    mandatory: true
     resources:
       online:
         type: vb
@@ -41,10 +37,6 @@ objects:
         type: vi
         access: r
   device:
-    object_id: 3
-    object_urn: urn:oma:lwm2m:oma:3
-    object_version: '1.1'
-    mandatory: true
     resources:
       device_type:
         type: vs
@@ -87,10 +79,6 @@ objects:
         access: rw
         description: UTC offset currently in effect for device
   firmware_update:
-    object_id: 5
-    object_urn: urn:oma:lwm2m:oma:5
-    object_version: '1.1'
-    mandatory: true
     resources:
       firmware_update_delivery_method:
         type: vi
@@ -121,8 +109,6 @@ objects:
       action_paused_until_1:
         type: vo
         access: rw
-        persistent: true
-        report_on_update: true
         description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
       battery_level:
         type: vi
@@ -130,33 +116,28 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: Battery level (100% is full)
       charging_cycles:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Number of completed charging cycles
       collisions:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Total number of collisions
       command:
         type: vi
         access: rw
-        report_on_update: true
         description: Command to execute
       cutting_time:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Time in hours that the cutting disc has been active
       data_download:
         type: vo
@@ -167,12 +148,10 @@ objects:
       device_type:
         type: vs
         access: r
-        report_on_update: true
         description: Device type identifier
       device_variant:
         type: vs
         access: r
-        report_on_update: true
         description: Device variant identifier
       guide_wire_length:
         type: vi
@@ -181,7 +160,6 @@ objects:
         min: 0
         max: 1000
         uninitialized: '0'
-        report_on_update: true
         description: Guide wire length in meters
       internal_connection_state:
         type: vi
@@ -191,7 +169,6 @@ objects:
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Last reported error code from the mower
       lona:
         type: vo
@@ -201,10 +178,8 @@ objects:
           - vi
           - vo
         access: rw
-        persistent: true
         encoding: hex
         uninitialized: empty
-        report_on_update: true
         description: LONA control flags (8 bytes, bit flags for LONA features)
       lona_mcu_boot_fw_version:
         type: vo
@@ -216,22 +191,18 @@ objects:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: LONA status (12 bytes, includes error code, zone tag, map tag, session ID)
       mainboard_version:
         type: vs
         access: r
-        report_on_update: true
         description: 'Mainboard version (format: XX.XX)'
       manual_operation:
         type: vi
         access: r
-        report_on_update: true
         description: Manual mode status (requires physical access)
       mmi_version:
         type: vs
         access: r
-        report_on_update: true
         description: 'MMI application version (format: XX.XX)'
       mower_timer_with_distance:
         type: vo
@@ -241,7 +212,6 @@ objects:
         access: r
         encoding: hex
         uninitialized: empty
-        report_on_update: true
         description: GNSS position and compass data (26 bytes, includes lat/lon, accuracy, heading)
       position_timer:
         type: vi
@@ -249,7 +219,6 @@ objects:
         unit: s
         min: 0
         max: 3600
-        report_on_update: true
         description: Duration for repeated position reporting (write >0 to start, 0 to stop)
       position_update_interval:
         type: vi
@@ -257,8 +226,6 @@ objects:
         unit: ms
         min: 1
         max: 3600000
-        persistent: true
-        report_on_update: true
         description: Time interval for position reporting
       rf_link_quality:
         type: vi
@@ -266,43 +233,34 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: RF link quality percentage
       running_time:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Time in hours that the wheel motors have been active
       schedule_config:
         type: vo
         access: rw
-        persistent: true
-        report_on_update: true
         description: Schedule configuration (up to 14 schedules, 7 bytes each)
       serial_number:
         type: vs
         access: r
-        report_on_update: true
         description: Mower serial number
       settings_control:
         type: vo
         access: rw
-        persistent: true
         encoding: hex
-        report_on_update: true
         description: Write settings (hex encoded custom buffer)
       settings_report:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Read settings (hex encoded custom buffer)
       source_for_next_start:
         type: vi
         access: r
-        report_on_update: true
         description: Source/reason for timestamp_next_start (no_source, daily_limit, week_timer, countdown, charging, auto_timer, frost)
       start_delay_ms:
         type: vi
@@ -310,42 +268,32 @@ objects:
       starting_points:
         type: vo
         access: rw
-        report_on_update: true
         description: Parameters for three starting points in mower binary format
       status:
         type: vi
         access: r
-        report_on_update: true
         description: Mower status (off, wait_for_safety, pause, running_mowing_timer, mowing, learning_wire, going_home, charging, error, software_update, wait_leaving_cs, leaving_cs, wait_for_new_task, startup)
       supported_starting_points:
         type: vi
         access: r
         min: 0
         max: 3
-        report_on_update: true
         description: Number of supported starting points
       supported_wires:
         type: vi
         access: r
         min: 0
         max: 255
-        report_on_update: true
         description: Bit mask for supported wire features
       timestamp_last_error_code:
         type: vo
         access: r
-        report_on_update: true
         description: Timestamp of last error code (seconds since 1970-01-01, local time)
       timestamp_next_start:
         type: vo
         access: r
-        report_on_update: true
         description: Estimated time of next automatic start (seconds since 1970-01-01, local time, 0=start now)
   lemonbeat_status_message:
-    object_id: 28173
-    object_urn: urn:oma:lwm2m:ext:28173
-    object_version: '0.1'
-    mandatory: false
     resources:
       code:
         type: vi

--- a/gardena_smart_local_api/schema/6146_sileno.yaml
+++ b/gardena_smart_local_api/schema/6146_sileno.yaml
@@ -10,20 +10,12 @@ commands:
   factory_reset_start_inclusion_mode: 43
 objects:
   connection_status:
-    object_id: 28171
-    object_urn: urn:oma:lwm2m:ext:28171
-    object_version: '0.2'
-    mandatory: true
     resources:
       online:
         type: vb
         access: r
         description: Indicates if the device is online (true) or offline (false)
   device:
-    object_id: 3
-    object_urn: urn:oma:lwm2m:oma:3
-    object_version: '1.1'
-    mandatory: true
     resources:
       device_type:
         type: vs
@@ -66,10 +58,6 @@ objects:
         access: rw
         description: UTC offset currently in effect for device
   firmware_update:
-    object_id: 5
-    object_urn: urn:oma:lwm2m:oma:5
-    object_version: '1.1'
-    mandatory: true
     resources:
       firmware_update_delivery_method:
         type: vi
@@ -100,8 +88,6 @@ objects:
       action_paused_until_1:
         type: vo
         access: rw
-        persistent: true
-        report_on_update: true
         description: 'Timestamp until the schedule is paused (Format: YYYYMMDDHHmm, local time)'
       battery_level:
         type: vi
@@ -109,43 +95,36 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: Battery level (100% is full)
       charging_cycles:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Number of completed charging cycles
       collisions:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Total number of collisions
       command:
         type: vi
         access: rw
-        report_on_update: true
         description: Command to execute
       cutting_time:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Time in hours that the cutting disc has been active
       device_type:
         type: vs
         access: r
-        report_on_update: true
         description: Device type identifier
       device_variant:
         type: vs
         access: r
-        report_on_update: true
         description: Device variant identifier
       internal_connection_state:
         type: vi
@@ -155,22 +134,18 @@ objects:
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Last reported error code from the mower
       mainboard_version:
         type: vs
         access: r
-        report_on_update: true
         description: 'Mainboard version (format: XX.XX)'
       manual_operation:
         type: vi
         access: r
-        report_on_update: true
         description: Manual mode status (requires physical access)
       mmi_version:
         type: vs
         access: r
-        report_on_update: true
         description: 'MMI application version (format: XX.XX)'
       mower_timer:
         type: vi
@@ -178,7 +153,6 @@ objects:
         unit: s
         min: -16777215
         max: 16777216
-        report_on_update: true
         description: Manual mowing timer (write >0=start, 0=stop, read >0=running, -16777215=schedule running)
       rf_link_quality:
         type: vi
@@ -186,43 +160,34 @@ objects:
         unit: '%'
         min: 0
         max: 100
-        report_on_update: true
         description: RF link quality percentage
       running_time:
         type: vi
         access: r
         min: 0
         max: 65535
-        report_on_update: true
         description: Time in hours that the wheel motors have been active
       schedule_config:
         type: vo
         access: rw
-        persistent: true
-        report_on_update: true
         description: Schedule configuration (up to 14 schedules, 7 bytes each)
       serial_number:
         type: vs
         access: r
-        report_on_update: true
         description: Mower serial number
       settings_control:
         type: vo
         access: rw
-        persistent: true
         encoding: hex
-        report_on_update: true
         description: Write settings (hex encoded custom buffer)
       settings_report:
         type: vo
         access: r
         encoding: hex
-        report_on_update: true
         description: Read settings (hex encoded custom buffer)
       source_for_next_start:
         type: vi
         access: r
-        report_on_update: true
         description: Source/reason for timestamp_next_start (no_source, daily_limit, week_timer, countdown, charging, auto_timer, frost)
       start_delay_ms:
         type: vi
@@ -230,42 +195,32 @@ objects:
       starting_points:
         type: vo
         access: rw
-        report_on_update: true
         description: Parameters for three starting points in mower binary format
       status:
         type: vi
         access: r
-        report_on_update: true
         description: Mower status (off, wait_for_safety, pause, running_mowing_timer, mowing, learning_wire, going_home, charging, error, software_update, wait_leaving_cs, leaving_cs, wait_for_new_task, startup)
       supported_starting_points:
         type: vi
         access: r
         min: 0
         max: 3
-        report_on_update: true
         description: Number of supported starting points
       supported_wires:
         type: vi
         access: r
         min: 0
         max: 255
-        report_on_update: true
         description: Bit mask for supported wire features
       timestamp_last_error_code:
         type: vo
         access: r
-        report_on_update: true
         description: Timestamp of last error code (seconds since 1970-01-01, local time)
       timestamp_next_start:
         type: vo
         access: r
-        report_on_update: true
         description: Estimated time of next automatic start (seconds since 1970-01-01, local time, 0=start now)
   lemonbeat_status_message:
-    object_id: 28173
-    object_urn: urn:oma:lwm2m:ext:28173
-    object_version: '0.1'
-    mandatory: false
     resources:
       code:
         type: vi


### PR DESCRIPTION
This metadata is currently not consistent. As we do not use this information, we might as well remove it.