### PR TITLE
Refactor gen1 mixins

### DIFF
--- a/gardena_smart_local_api/devices/gen1.py
+++ b/gardena_smart_local_api/devices/gen1.py
@@ -39,6 +39,21 @@ class IdentifyMixin:
         return self.build_command_obj(self.get_command("hap_identify"))
 
 
+class Gen1FrostWarningMixin:
+    @property
+    def has_frost_warning(self: _Gen1DeviceProtocol) -> bool | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="frost_warning",
+            )
+        )
+        if isinstance(value, int):
+            return bool(value)
+        return None
+
+
 class Gen1Device(Device):
     model_definition: Gen1ModelDefinition = Field()
     service: ClassVar[str] = "lemonbeatd"

--- a/gardena_smart_local_api/devices/gen1.py
+++ b/gardena_smart_local_api/devices/gen1.py
@@ -34,7 +34,7 @@ class Gen1BatteryMixin:
         return self.build_command_obj(self.get_command("measure_battery"))
 
 
-class IdentifyMixin:
+class Gen1IdentifyMixin:
     def build_identify_obj(self: _Gen1DeviceProtocol) -> EgressMessageList:
         return self.build_command_obj(self.get_command("hap_identify"))
 

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 from ..messages import EgressMessageList
 from ..resources import IpsoPath
-from .gen1 import Gen1BatteryMixin, Gen1Device, IdentifyMixin
+from .gen1 import Gen1BatteryMixin, Gen1Device, Gen1FrostWarningMixin, IdentifyMixin
 from .gen2 import Gen2BatteryMixin, Gen2Device
 
 # Used to indicate that the action was initiated through WebSocket API.
@@ -88,7 +88,9 @@ class _Gen1Irrigation(Gen1Device, ABC):
     def build_close_all_valves_obj(self) -> EgressMessageList: ...
 
 
-class Gen1WaterControl(_Gen1Irrigation, Gen1BatteryMixin, IdentifyMixin):
+class Gen1WaterControl(
+    _Gen1Irrigation, Gen1BatteryMixin, IdentifyMixin, Gen1FrostWarningMixin
+):
     @property
     def valve_count(self) -> int:
         return 1
@@ -121,19 +123,6 @@ class Gen1WaterControl(_Gen1Irrigation, Gen1BatteryMixin, IdentifyMixin):
         )
         if isinstance(value, int):
             return value
-        return None
-
-    @property
-    def has_frost_warning(self) -> bool | None:
-        value = self.get_value(
-            IpsoPath(
-                object_name="lemonbeat",
-                object_instance_id="0",
-                resource_name="frost_warning",
-            )
-        )
-        if isinstance(value, int):
-            return bool(value)
         return None
 
     def build_close_all_valves_obj(self) -> EgressMessageList:

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -89,7 +89,7 @@ class _Gen1Irrigation(Gen1Device, ABC):
 
 
 class Gen1WaterControl(
-    _Gen1Irrigation, Gen1BatteryMixin, Gen1IdentifyMixin, Gen1FrostWarningMixin
+    Gen1BatteryMixin, Gen1IdentifyMixin, Gen1FrostWarningMixin, _Gen1Irrigation
 ):
     @property
     def valve_count(self) -> int:
@@ -148,7 +148,7 @@ class Gen1WaterControl(
         )
 
 
-class Gen1IrrigationControl(_Gen1Irrigation, Gen1IdentifyMixin):
+class Gen1IrrigationControl(Gen1IdentifyMixin, _Gen1Irrigation):
     @property
     def valve_count(self) -> int:
         return 6

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 from ..messages import EgressMessageList
 from ..resources import IpsoPath
-from .gen1 import Gen1BatteryMixin, Gen1Device, Gen1FrostWarningMixin, IdentifyMixin
+from .gen1 import Gen1BatteryMixin, Gen1Device, Gen1FrostWarningMixin, Gen1IdentifyMixin
 from .gen2 import Gen2BatteryMixin, Gen2Device
 
 # Used to indicate that the action was initiated through WebSocket API.
@@ -89,7 +89,7 @@ class _Gen1Irrigation(Gen1Device, ABC):
 
 
 class Gen1WaterControl(
-    _Gen1Irrigation, Gen1BatteryMixin, IdentifyMixin, Gen1FrostWarningMixin
+    _Gen1Irrigation, Gen1BatteryMixin, Gen1IdentifyMixin, Gen1FrostWarningMixin
 ):
     @property
     def valve_count(self) -> int:
@@ -148,7 +148,7 @@ class Gen1WaterControl(
         )
 
 
-class Gen1IrrigationControl(_Gen1Irrigation, IdentifyMixin):
+class Gen1IrrigationControl(_Gen1Irrigation, Gen1IdentifyMixin):
     @property
     def valve_count(self) -> int:
         return 6

--- a/gardena_smart_local_api/devices/power.py
+++ b/gardena_smart_local_api/devices/power.py
@@ -1,9 +1,9 @@
 from ..messages import EgressMessageList
 from ..resources import IpsoPath
-from .gen1 import Gen1Device, IdentifyMixin
+from .gen1 import Gen1Device, Gen1IdentifyMixin
 
 
-class PowerAdapter(IdentifyMixin, Gen1Device):
+class PowerAdapter(Gen1IdentifyMixin, Gen1Device):
     @property
     def power_timer(self) -> int | None:
         value = self.get_value(

--- a/gardena_smart_local_api/devices/sensors.py
+++ b/gardena_smart_local_api/devices/sensors.py
@@ -1,22 +1,9 @@
 from ..messages import EgressMessageList
 from ..resources import IpsoPath
-from .gen1 import Gen1BatteryMixin, Gen1Device, IdentifyMixin
+from .gen1 import Gen1BatteryMixin, Gen1Device, Gen1FrostWarningMixin, IdentifyMixin
 
 
-class _Sensor(Gen1Device, Gen1BatteryMixin, IdentifyMixin):
-    @property
-    def has_frost_warning(self) -> bool | None:
-        value = self.get_value(
-            IpsoPath(
-                object_name="lemonbeat",
-                object_instance_id="0",
-                resource_name="frost_warning",
-            )
-        )
-        if isinstance(value, int):
-            return bool(value)
-        return None
-
+class _Sensor(Gen1Device, Gen1BatteryMixin, IdentifyMixin, Gen1FrostWarningMixin):
     def build_refresh_soil_moisture_obj(self) -> EgressMessageList:
         return self.build_command_obj(self.get_command("measure_soil_moisture"))
 

--- a/gardena_smart_local_api/devices/sensors.py
+++ b/gardena_smart_local_api/devices/sensors.py
@@ -1,9 +1,9 @@
 from ..messages import EgressMessageList
 from ..resources import IpsoPath
-from .gen1 import Gen1BatteryMixin, Gen1Device, Gen1FrostWarningMixin, IdentifyMixin
+from .gen1 import Gen1BatteryMixin, Gen1Device, Gen1FrostWarningMixin, Gen1IdentifyMixin
 
 
-class _Sensor(Gen1Device, Gen1BatteryMixin, IdentifyMixin, Gen1FrostWarningMixin):
+class _Sensor(Gen1Device, Gen1BatteryMixin, Gen1IdentifyMixin, Gen1FrostWarningMixin):
     def build_refresh_soil_moisture_obj(self) -> EgressMessageList:
         return self.build_command_obj(self.get_command("measure_soil_moisture"))
 

--- a/gardena_smart_local_api/devices/sensors.py
+++ b/gardena_smart_local_api/devices/sensors.py
@@ -3,7 +3,7 @@ from ..resources import IpsoPath
 from .gen1 import Gen1BatteryMixin, Gen1Device, Gen1FrostWarningMixin, Gen1IdentifyMixin
 
 
-class _Sensor(Gen1Device, Gen1BatteryMixin, Gen1IdentifyMixin, Gen1FrostWarningMixin):
+class _Sensor(Gen1BatteryMixin, Gen1IdentifyMixin, Gen1FrostWarningMixin, Gen1Device):
     def build_refresh_soil_moisture_obj(self) -> EgressMessageList:
         return self.build_command_obj(self.get_command("measure_soil_moisture"))
 


### PR DESCRIPTION
## Summary
- Extract `has_frost_warning` into `Gen1FrostWarningMixin` to avoid duplication
- Rename `IdentifyMixin` to `Gen1IdentifyMixin` for consistency
- Put mixins before base class following Python MRO best practice

## Test plan
- [ ] All existing tests pass (`uv run pytest`)