### PR TITLE
Check formatting in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           uv run ruff check
 
+      - name: Run format check
+        run: |
+          uv run ruff format --check
+
       - name: Run tests with coverage
         run: |
           uv run pytest --cov=gardena_smart_local_api --cov-report=term --cov-report=xml

--- a/gardena_smart_local_api/examples/inclusion.py
+++ b/gardena_smart_local_api/examples/inclusion.py
@@ -48,9 +48,7 @@ async def main():
             if answer.strip().lower() != "y":
                 continue
 
-            replies = await app.send_request(
-                build_inclusion_obj(service, instance_id)
-            )
+            replies = await app.send_request(build_inclusion_obj(service, instance_id))
             if replies and isinstance(replies[0], Reply) and replies[0].success:
                 print(f"[green]Device {device_desc} included successfully.[/green]")
                 return 0


### PR DESCRIPTION
## Summary
- Add `ruff format --check` step to CI to catch unformatted code on PRs.
- Format `inclusion.py` (preexisting violation surfaced by the new check).