### PR TITLE
Remove checked in file from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ ENV/
 env.bak/
 venv.bak/
 .python-version
-uv.lock
 
 # MacOS stuff
 .DS_Store


### PR DESCRIPTION
We have uv.lock checked into Git, and it makes sense to me. We should however remove it from .gitignore in order to avoid confusion.