### PR TITLE
Replace Pump valve API with start/stop methods

### DIFF
--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -271,17 +271,34 @@ class Gen2IrrigationControl(_Gen2Irrigation):
     pass
 
 
-class Pump(Gen1IdentifyMixin, Gen1FrostWarningMixin, _Gen1Irrigation):
+class Pump(Gen1IdentifyMixin, Gen1FrostWarningMixin, Gen1Device):
     @property
-    def valve_count(self) -> int:
-        return 1
+    def watering_timer(self) -> int | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="watering_timer_1",
+            )
+        )
+        if isinstance(value, int):
+            return value
+        return None
 
-    @property
-    def valve_ids(self) -> list[int]:
-        return [0]
+    def build_start_obj(
+        self, duration_seconds: int = DEFAULT_WATERING_DURATION
+    ) -> EgressMessageList:
+        return self.build_write_value_obj(
+            IpsoPath(
+                object_name="lemonbeat",
+                object_instance_id="0",
+                resource_name="watering_timer_1",
+            ),
+            duration_seconds,
+        )
 
-    def build_close_all_valves_obj(self) -> EgressMessageList:
-        return self.build_close_valve_obj(valve_id=0)
+    def build_stop_obj(self) -> EgressMessageList:
+        return self.build_start_obj(0)
 
     @property
     def pump_mode(self) -> PumpMode | None:

--- a/gardena_smart_local_api/examples/pump.py
+++ b/gardena_smart_local_api/examples/pump.py
@@ -62,7 +62,7 @@ async def main():
                 print(f"Pump state:          {pump.pump_state}")
                 print(f"Pump mode:           {pump.pump_mode}")
                 print(f"Operating mode:      {pump.operating_mode}")
-                print(f"Watering timer:      {pump.get_watering_timer(0)} s")
+                print(f"Watering timer:      {pump.watering_timer} s")
                 print()
                 print(f"Outlet pressure:     {pump.outlet_pressure} Bar")
                 print(f"Outlet pressure max: {pump.outlet_pressure_max} Bar")
@@ -82,7 +82,7 @@ async def main():
                     return 1
                 assert isinstance(pump, COMPATIBLE)
                 duration = int(app.args.value) if app.args.value is not None else 60
-                request = pump.build_open_valve_obj(0, duration)
+                request = pump.build_start_obj(duration)
                 result = await app.send_request(request)
                 if result is not None and not result[0].success:
                     print("Failed to start pump")
@@ -94,7 +94,7 @@ async def main():
                 if (pump := app.device) is None:
                     return 1
                 assert isinstance(pump, COMPATIBLE)
-                request = pump.build_close_valve_obj(0)
+                request = pump.build_stop_obj()
                 result = await app.send_request(request)
                 if result is not None and not result[0].success:
                     print("Failed to stop pump")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["gardena_smart_local_api"]
 
 [project]
 name = "gardena-smart-local-api"
-version = "0.0.9"
+version = "0.0.10"
 description = "Library to interact with the local GARDENA smart API."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_epp.py
+++ b/tests/test_epp.py
@@ -87,20 +87,10 @@ async def test_epp_operating_mode(epp):
 
 
 @pytest.mark.asyncio
-async def test_epp_valve_count(epp):
-    assert epp.valve_count == 1
-
-
-@pytest.mark.asyncio
-async def test_epp_valve_ids(epp):
-    assert epp.valve_ids == [0]
+async def test_epp_has_no_valves(epp):
+    assert not hasattr(epp, "valve_ids")
 
 
 @pytest.mark.asyncio
 async def test_epp_watering_timer(epp):
-    assert epp.get_watering_timer(0) == 0
-
-
-@pytest.mark.asyncio
-async def test_epp_is_valve_open(epp):
-    assert epp.is_valve_open(0) is False
+    assert epp.watering_timer == 0

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "gardena-smart-local-api"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
A pump only switches on/off, so only expose dedicated start/stop methods instead of valves.