### PR TITLE
Water Control duo fixes

### DIFF
--- a/gardena_smart_local_api/devices/device.py
+++ b/gardena_smart_local_api/devices/device.py
@@ -84,6 +84,25 @@ class Device(BaseModel):
             delete_nested_key(self.data, event.entity.path)
             deep_merge_dict(self.data, nested)
 
+        self._invalidate_objects_cache(event.entity.path)
+
+    def _invalidate_objects_cache(self, path: IpsoPath) -> None:
+        cached = self.__dict__.get("objects")
+        if cached is None:
+            return
+
+        object_name = path.object_name
+        instance_id = path.object_instance_id
+        if object_name is None or instance_id is None:
+            return
+
+        object_data = self.model_definition.objects.get(object_name)
+        if not object_data or not object_data.get("multi_instance", False):
+            return
+
+        if instance_id not in cached.get(object_name, {}):
+            del self.__dict__["objects"]
+
     def get_value(self, path: IpsoPath) -> VALUE_TYPES | None:
         obj = self.data
         for key in path.segments:

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -245,7 +245,19 @@ class _Gen2Irrigation(Gen2Device):
     def is_valve_open(self, valve_id: int = 0) -> bool | None:
         if valve_id not in self.valve_ids:
             raise ValueError(f"Invalid valve ID {valve_id}")
-        return self.get_timeslot_state(valve_id) == TimeslotState.RUNNING
+        for timeslot_id in self.get_object_instance_ids("timeslot"):
+            if self.get_timeslot_state(int(timeslot_id)) != TimeslotState.RUNNING:
+                continue
+            actuator = self.get_value(
+                IpsoPath(
+                    object_name="timeslot",
+                    object_instance_id=timeslot_id,
+                    resource_name="actuator",
+                )
+            )
+            if actuator == valve_id:
+                return True
+        return False
 
     def get_timeslot_state(self, timeslot_id: int) -> TimeslotState | None:
         value = self.get_value(


### PR DESCRIPTION
- valve open property assumed actuator id == valve id, but this is not the case (for manual triggers)
- objects property is cached as it loads the static schema, but for multi instance elements this lead to valves not showing up in HA integration