### PR TITLE
Firmware version & update support

### DIFF
--- a/gardena_smart_local_api/devices/__init__.py
+++ b/gardena_smart_local_api/devices/__init__.py
@@ -5,6 +5,7 @@
 from .device import (
     Device,
     DeviceMap,
+    FirmwareUpdateResult,
     FirmwareUpdateState,
     build_discovery_obj,
     build_inclusion_obj,
@@ -33,6 +34,7 @@ from .sensors import Sensor1, Sensor2
 __all__ = [
     "Device",
     "DeviceMap",
+    "FirmwareUpdateResult",
     "FirmwareUpdateState",
     "Gen1IrrigationControl",
     "Gen1Mower1",

--- a/gardena_smart_local_api/devices/__init__.py
+++ b/gardena_smart_local_api/devices/__init__.py
@@ -2,7 +2,13 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-from .device import Device, DeviceMap, build_discovery_obj, build_inclusion_obj
+from .device import (
+    Device,
+    DeviceMap,
+    FirmwareUpdateState,
+    build_discovery_obj,
+    build_inclusion_obj,
+)
 from .device_builder import (
     create_devices_from_json,
     create_devices_from_messages,
@@ -27,6 +33,7 @@ from .sensors import Sensor1, Sensor2
 __all__ = [
     "Device",
     "DeviceMap",
+    "FirmwareUpdateState",
     "Gen1IrrigationControl",
     "Gen1Mower1",
     "Gen1Mower2",

--- a/gardena_smart_local_api/devices/device.py
+++ b/gardena_smart_local_api/devices/device.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
+import re
 from collections.abc import MutableMapping
 from functools import cached_property
 from typing import Any, ClassVar, cast
@@ -370,6 +371,41 @@ class Device(BaseModel):
                 object_name="firmware_update",
                 object_instance_id="0",
                 resource_name="state",
+            )
+        )
+
+    @property
+    def available_firmware_version(self) -> str | None:
+        """Version of the pending firmware update, ``None`` if up to date."""
+        value = self.get_value(
+            IpsoPath(
+                object_name="firmware_update",
+                object_instance_id="0",
+                resource_name="pkg_version",
+            )
+        )
+        return str(value) if value else None
+
+    @property
+    def available_software_version(self) -> str | None:
+        """Software version extracted from :attr:`available_firmware_version`."""
+        firmware_version = self.available_firmware_version
+        if not firmware_version:
+            return None
+        match = re.search(r"SwPkg(?:[_-][a-zA-Z0-9]+)*[_-](\d+\.\d+)", firmware_version)
+        if match:
+            return match.group(1)
+        match = re.fullmatch(r"(.+)-(.+)-(.+)", firmware_version)
+        if match:
+            return match.group(3)
+        return firmware_version
+
+    def build_refresh_available_firmware_version_obj(self) -> EgressMessageList:
+        return self.build_read_value_obj(
+            IpsoPath(
+                object_name="firmware_update",
+                object_instance_id="0",
+                resource_name="pkg_version",
             )
         )
 

--- a/gardena_smart_local_api/devices/device.py
+++ b/gardena_smart_local_api/devices/device.py
@@ -23,6 +23,19 @@ class FirmwareUpdateState(_LowerNameEnum):
     UPDATING = 3
 
 
+class FirmwareUpdateResult(_LowerNameEnum):
+    INITIAL = 0
+    SUCCESS = 1
+    NOT_ENOUGH_FLASH = 2
+    OUT_OF_RAM = 3
+    CONNECTION_LOST = 4
+    INTEGRITY_CHECK_FAILURE = 5
+    UNSUPPORTED_PACKAGE_TYPE = 6
+    INVALID_URI = 7
+    UPDATE_FAILED = 8
+    UNSUPPORTED_PROTOCOL = 9
+
+
 def _value_to_payload[T: VALUE_TYPES](value: T) -> dict[str, T]:
     SCALAR_TYPE_MAP = {
         bool: "vb",
@@ -371,6 +384,31 @@ class Device(BaseModel):
                 object_name="firmware_update",
                 object_instance_id="0",
                 resource_name="state",
+            )
+        )
+
+    @property
+    def firmware_update_result(self) -> FirmwareUpdateResult | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="firmware_update",
+                object_instance_id="0",
+                resource_name="update_result",
+            )
+        )
+        if isinstance(value, int):
+            try:
+                return FirmwareUpdateResult(value)
+            except ValueError:
+                pass
+        return None
+
+    def build_refresh_firmware_update_result_obj(self) -> EgressMessageList:
+        return self.build_read_value_obj(
+            IpsoPath(
+                object_name="firmware_update",
+                object_instance_id="0",
+                resource_name="update_result",
             )
         )
 

--- a/gardena_smart_local_api/devices/device.py
+++ b/gardena_smart_local_api/devices/device.py
@@ -409,6 +409,16 @@ class Device(BaseModel):
             )
         )
 
+    def build_install_firmware_update_obj(self) -> EgressMessageList:
+        return self.build_execute_obj(
+            IpsoPath(
+                object_name="firmware_update",
+                object_instance_id="0",
+                resource_name="update",
+            ),
+            None,
+        )
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(id={self.id!r}, "

--- a/gardena_smart_local_api/devices/device.py
+++ b/gardena_smart_local_api/devices/device.py
@@ -12,6 +12,14 @@ from ..messages import EgressMessageList, Entity, Event, Request
 from ..model_loader import ModelDefinition, get_model_loader
 from ..resources import VALUE_TYPES, IpsoObject, IpsoPath, ValueField
 from ..utils import deep_merge_dict, delete_nested_key
+from ._enums import _LowerNameEnum
+
+
+class FirmwareUpdateState(_LowerNameEnum):
+    IDLE = 0
+    DOWNLOADING = 1
+    DOWNLOADED = 2
+    UPDATING = 3
 
 
 def _value_to_payload[T: VALUE_TYPES](value: T) -> dict[str, T]:
@@ -339,6 +347,31 @@ class Device(BaseModel):
             )
         )
         return str(value) if value else None
+
+    @property
+    def firmware_update_state(self) -> FirmwareUpdateState | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="firmware_update",
+                object_instance_id="0",
+                resource_name="state",
+            )
+        )
+        if isinstance(value, int):
+            try:
+                return FirmwareUpdateState(value)
+            except ValueError:
+                pass
+        return None
+
+    def build_refresh_firmware_update_state_obj(self) -> EgressMessageList:
+        return self.build_read_value_obj(
+            IpsoPath(
+                object_name="firmware_update",
+                object_instance_id="0",
+                resource_name="state",
+            )
+        )
 
     def __repr__(self) -> str:
         return (

--- a/gardena_smart_local_api/examples/device.py
+++ b/gardena_smart_local_api/examples/device.py
@@ -18,8 +18,11 @@ extra_args = [
     {
         "name_or_flags": ["command"],
         "nargs": 1,
-        "choices": ("list", "include", "exclude"),
-        "help": "List included devices, include a new device, or exclude a device",
+        "choices": ("list", "info", "include", "exclude"),
+        "help": (
+            "List included devices, show device info, "
+            "include a new device, or exclude a device"
+        ),
     },
 ]
 
@@ -70,6 +73,25 @@ async def include(app: ExampleApp) -> int:
             return 1
 
 
+async def info(app: ExampleApp) -> int:
+    if (device := app.device) is None:
+        return 1
+
+    out = f"Device {device.id} ({device.model_definition.name}):\n"
+    out += f"  Manufacturer:    {device.manufacturer}\n"
+    out += f"  Serial number:   {device.serial_number}\n"
+    out += f"  Software version: {device.software_version}\n"
+    out += f"  Hardware version: {device.hardware_version}\n"
+    out += f"  Online:          {device.is_online}\n"
+    out += f"  Firmware update: {device.firmware_update_state}"
+    if (battery_level := getattr(device, "battery_level", None)) is not None:
+        out += f"\n  Battery:         {battery_level}%"
+    if (rf_link_quality := getattr(device, "rf_link_quality", None)) is not None:
+        out += f"\n  RF link quality: {rf_link_quality}%"
+    print(out)
+    return 0
+
+
 async def exclude(app: ExampleApp) -> int:
     device_id = app.args.device_id
     if device_id is None:
@@ -102,6 +124,9 @@ async def main():
             case "list":
                 app.list_devices()
                 return 0
+
+            case "info":
+                return await info(app)
 
             case "include":
                 return await include(app)

--- a/gardena_smart_local_api/examples/device.py
+++ b/gardena_smart_local_api/examples/device.py
@@ -80,10 +80,12 @@ async def info(app: ExampleApp) -> int:
     out = f"Device {device.id} ({device.model_definition.name}):\n"
     out += f"  Manufacturer:    {device.manufacturer}\n"
     out += f"  Serial number:   {device.serial_number}\n"
-    out += f"  Software version: {device.software_version}\n"
+    out += f"  Software version: {device.software_version}"
+    if (available := device.available_software_version) is not None:
+        out += f" [yellow]→ {available} ({device.firmware_update_state})[/yellow]"
+    out += "\n"
     out += f"  Hardware version: {device.hardware_version}\n"
-    out += f"  Online:          {device.is_online}\n"
-    out += f"  Firmware update: {device.firmware_update_state}"
+    out += f"  Online:          {device.is_online}"
     if (battery_level := getattr(device, "battery_level", None)) is not None:
         out += f"\n  Battery:         {battery_level}%"
     if (rf_link_quality := getattr(device, "rf_link_quality", None)) is not None:

--- a/gardena_smart_local_api/examples/device.py
+++ b/gardena_smart_local_api/examples/device.py
@@ -9,19 +9,26 @@ import sys
 
 from rich import print
 
-from gardena_smart_local_api.devices import Device, build_inclusion_obj
+from gardena_smart_local_api.devices import (
+    Device,
+    FirmwareUpdateResult,
+    FirmwareUpdateState,
+    build_inclusion_obj,
+)
 from gardena_smart_local_api.examples import ExampleApp
 from gardena_smart_local_api.messages import Reply
 from gardena_smart_local_api.sgtin96 import SGTIN96Info
+
+UPDATE_TIMEOUT_SECONDS = 600
 
 extra_args = [
     {
         "name_or_flags": ["command"],
         "nargs": 1,
-        "choices": ("list", "info", "include", "exclude"),
+        "choices": ("list", "info", "include", "exclude", "update"),
         "help": (
-            "List included devices, show device info, "
-            "include a new device, or exclude a device"
+            "List included devices, show device info, include a new device, "
+            "exclude a device, or install a firmware update"
         ),
     },
 ]
@@ -94,6 +101,52 @@ async def info(app: ExampleApp) -> int:
     return 0
 
 
+async def update(app: ExampleApp) -> int:
+    if (device := app.device) is None:
+        return 1
+
+    if (available := device.available_software_version) is None:
+        print("[green]No firmware update available.[/green]")
+        return 0
+
+    print(
+        f"Firmware update available: {device.software_version} "
+        f"[yellow]→ {available}[/yellow]"
+    )
+    answer = await prompt("Install update? [y/N] ")
+    if answer.strip().lower() != "y":
+        return 0
+
+    replies = await app.send_request(device.build_install_firmware_update_obj())
+    if not replies or not isinstance(replies[0], Reply) or not replies[0].success:
+        print("[red]Failed to trigger firmware update.[/red]")
+        return 1
+
+    print("Installing firmware update, this may take a while...")
+    last_state = None
+    started = False
+    for _ in range(UPDATE_TIMEOUT_SECONDS):
+        state = device.firmware_update_state
+        if state != last_state:
+            print(f"  State: {state}")
+            last_state = state
+        if state not in (None, FirmwareUpdateState.IDLE):
+            started = True
+        elif started and state == FirmwareUpdateState.IDLE:
+            break
+        await asyncio.sleep(1)
+    else:
+        print("[red]Timeout waiting for firmware update to finish.[/red]")
+        return 1
+
+    result = device.firmware_update_result
+    if result == FirmwareUpdateResult.SUCCESS:
+        print(f"[green]Firmware update successful ({result}).[/green]")
+        return 0
+    print(f"[red]Firmware update failed ({result}).[/red]")
+    return 1
+
+
 async def exclude(app: ExampleApp) -> int:
     device_id = app.args.device_id
     if device_id is None:
@@ -135,6 +188,9 @@ async def main():
 
             case "exclude":
                 return await exclude(app)
+
+            case "update":
+                return await update(app)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds firmware update support to devices: read the installed and available versions, see the update state and last update result, and trigger a pending update.
The device example CLI shows an available update inline info and gets a new update command to install it and report the outcome.

### NOTE

Set fota loop for easy testing

set `fota_loop: true` in `/etc/fwrolloutd.yml`
and restart fwrolloutd: `systemctl restart fwrolloutd`