### PR TITLE
Add ambient temperature to Gen2 water controls

### DIFF
--- a/gardena_smart_local_api/devices/gen2.py
+++ b/gardena_smart_local_api/devices/gen2.py
@@ -32,6 +32,28 @@ class Gen2BatteryMixin:
         return None
 
 
+class Gen2TemperatureMixin:
+    @property
+    def temperature(self: _DeviceProtocol) -> float | None:
+        """
+        All battery driven Gen2 water controls have an ambient temperature entity.
+
+        The temperature is measured roughly every 31 minutes and every time the
+        valve changes its state. Reports are sent when the temperature difference is
+        greater than 2°C since the last report. Around the frost warning temperature of
+        4.0°C (±0.25°C hysteresis), the update occurs also when the frost warning state
+        changes.
+        """
+        value = self.get_value(
+            IpsoPath(
+                object_name="temperature",
+                object_instance_id="0",
+                resource_name="sensor_value",
+            )
+        )
+        return value if isinstance(value, float) else None
+
+
 class Gen2Device(Device):
     model_definition: Gen2ModelDefinition = Field()
     service: ClassVar[str] = "lwm2mserver"

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -14,7 +14,7 @@ from .gen1 import (
     Gen1IdentifyMixin,
     _Gen1DeviceProtocol,
 )
-from .gen2 import Gen2BatteryMixin, Gen2Device
+from .gen2 import Gen2BatteryMixin, Gen2Device, Gen2TemperatureMixin
 
 # Used to indicate that the action was initiated through WebSocket API.
 COMMAND_SOURCE = "18"
@@ -326,7 +326,7 @@ class _Gen2Irrigation(Gen2Device):
         return None
 
 
-class Gen2WaterControl(Gen2BatteryMixin, _Gen2Irrigation):
+class Gen2WaterControl(Gen2BatteryMixin, Gen2TemperatureMixin, _Gen2Irrigation):
     pass
 
 


### PR DESCRIPTION
All battery operated Gen2 devices have an ambient temperature sensor entity.

<img width="566" height="483" alt="smart pipeline ambient temperature" src="https://github.com/user-attachments/assets/dd0cdac3-3948-4777-9316-8715230c8412" />
