### PR TITLE
Document device type generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@ Enables controlling and monitoring GARDENA smart devices in the local network, w
 
 ## Supported Devices
 
-| Device                             | Article Number                             | Model (EAN suffix) |
-| ---------------------------------- | ------------------------------------------ | ------------------ |
-| smart Sensor                       | 19030-20                                   | 18845              |
-| smart Sensor II                    | 19040-20                                   | 19040              |
-| smart Water Control                | 19031-20                                   | 18869              |
-| smart Water Control                | 19033-20                                   | 2812               |
-| smart Dual Water Control           | 19034-20                                   | 2814               |
-| smart Pipeline Water Control       | 19050-20                                   | 2826               |
-| smart Automatic Home & Garden Pump | 19080-20                                   | 22538              |
-| smart Irrigation Control           | 19032-20                                   | 31653              |
-| smart Irrigation Control           | 19035-20                                   | 469                |
-| smart Power Adapter                | 19095-20                                   | 35279              |
-| smart SILENO                       | 19060-20, 19060-60                         | 6146               |
-| smart SILENO+                      | 19061-20, 19061-60, 19064-60, 19065-60     | 6146               |
-| smart SILENO city                  | 19066-20, 19069-20                         | 29694              |
-| smart SILENO life                  | 19113-20, 19114-20, 19115-20               | 29694              |
-| smart SILENO city (with LONA)      | 19602-66, 19603-60, 19605-60               | 53988              |
-| smart SILENO life (with LONA)      | 19701-60, 19702-60, 19703-66, 19704-60     | 53988              |
-| smart SILENO pro                   | 19802-20, 19802-22                         | 488                |
-| smart SILENO max                   | 19901-22                                   | 488                |
-| smart SILENO free                  | 19921-22, 19922-22, 19923-22               | 488                |
-| Flymo UltraLife                    | 970620501, 970620701, 970715101, 970715201 | 488                |
+| Device                             | Article Number                             | Model (EAN suffix) | Stack   |
+| ---------------------------------- | ------------------------------------------ | ------------------ | ------- |
+| smart Sensor                       | 19030-20                                   | 18845              | 1st gen |
+| smart Sensor II                    | 19040-20                                   | 19040              | 1st gen |
+| smart Water Control                | 19031-20                                   | 18869              | 1st gen |
+| smart Water Control                | 19033-20                                   | 2812               | 2nd gen |
+| smart Dual Water Control           | 19034-20                                   | 2814               | 2nd gen |
+| smart Pipeline Water Control       | 19050-20                                   | 2826               | 2nd gen |
+| smart Automatic Home & Garden Pump | 19080-20                                   | 22538              | 1st gen |
+| smart Irrigation Control           | 19032-20                                   | 31653              | 1st gen |
+| smart Irrigation Control           | 19035-20                                   | 469                | 2nd gen |
+| smart Power Adapter                | 19095-20                                   | 35279              | 1st gen |
+| smart SILENO                       | 19060-20, 19060-60                         | 6146               | 1st gen |
+| smart SILENO+                      | 19061-20, 19061-60, 19064-60, 19065-60     | 6146               | 1st gen |
+| smart SILENO city                  | 19066-20, 19069-20                         | 29694              | 1st gen |
+| smart SILENO life                  | 19113-20, 19114-20, 19115-20               | 29694              | 1st gen |
+| smart SILENO city (with LONA)      | 19602-66, 19603-60, 19605-60               | 53988              | 1st gen |
+| smart SILENO life (with LONA)      | 19701-60, 19702-60, 19703-66, 19704-60     | 53988              | 1st gen |
+| smart SILENO pro                   | 19802-20, 19802-22                         | 488                | 2nd gen |
+| smart SILENO max                   | 19901-22                                   | 488                | 2nd gen |
+| smart SILENO free                  | 19921-22, 19922-22, 19923-22               | 488                | 2nd gen |
+| Flymo UltraLife                    | 970620501, 970620701, 970715101, 970715201 | 488                | 2nd gen |
 
 ## Installation
 


### PR DESCRIPTION
The code contains quite some abstraction based on the tech stack used on the 1st gen (Lemonbeat DDK) and 2nd gen (BNW) devices. Properly documenting the generation of each device type helps people from outside of Gardena to make sense of the code.