### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["gardena_smart_local_api"]
 
 [project]
 name = "gardena-smart-local-api"
-version = "0.0.11"
+version = "0.1.0"
 description = "Library to interact with the local GARDENA smart API."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "gardena-smart-local-api"
-version = "0.0.11"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
## Summary
- Firmware update, gen2 ambient temperature and read/clear schedule support landed since v0.0.11 — warrants a minor bump per semver.