### PR TITLE
Add button config time read/write for Gen2 water controls

### DIFF
--- a/gardena_smart_local_api/devices/__init__.py
+++ b/gardena_smart_local_api/devices/__init__.py
@@ -15,6 +15,7 @@ from .device_builder import (
     create_devices_from_messages,
 )
 from .irrigation import (
+    ButtonTimeMixin,
     Gen1IrrigationControl,
     Gen1WaterControl,
     Gen2IrrigationControl,
@@ -32,6 +33,7 @@ from .power import PowerAdapter
 from .sensors import Sensor1, Sensor2
 
 __all__ = [
+    "ButtonTimeMixin",
     "Device",
     "DeviceMap",
     "FirmwareUpdateResult",

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 from abc import ABC, abstractmethod
+from typing import ClassVar, Protocol
 
 from ..messages import EgressMessageList
-from ..resources import IpsoPath
+from ..resources import VALUE_TYPES, IpsoPath
 from ._enums import _LowerNameEnum
 from .gen1 import (
     Gen1BatteryMixin,
@@ -109,6 +110,60 @@ class Gen1IrrigationScheduleMixin:
         )
 
 
+class _ButtonTimeDeviceProtocol(Protocol):
+    """Used to satisfy the type checker."""
+
+    _button_time_ipso_names: ClassVar[tuple[str, str]]
+
+    @property
+    def valve_ids(self) -> list[int]: ...
+    def get_value(self, path: IpsoPath) -> VALUE_TYPES | None: ...
+    def build_read_value_obj(self, path: IpsoPath) -> EgressMessageList: ...
+    def build_write_value_obj(
+        self, path: IpsoPath, value: VALUE_TYPES
+    ) -> EgressMessageList: ...
+    def _button_config_time_path(self, valve_id: int) -> IpsoPath: ...
+
+
+class ButtonTimeMixin:
+    """Devices with a manual button whose default watering duration is configurable."""
+
+    # (object_name, resource_name) of the button time resource.
+    _button_time_ipso_names: ClassVar[tuple[str, str]]
+
+    def _button_config_time_path(
+        self: _ButtonTimeDeviceProtocol, valve_id: int
+    ) -> IpsoPath:
+        if valve_id not in self.valve_ids:
+            raise ValueError(f"Invalid valve ID {valve_id}")
+        object_name, resource_name = self._button_time_ipso_names
+        return IpsoPath(
+            object_name=object_name,
+            object_instance_id=str(valve_id),
+            resource_name=resource_name,
+        )
+
+    def get_button_config_time(
+        self: _ButtonTimeDeviceProtocol, valve_id: int = 0
+    ) -> int | None:
+        value = self.get_value(self._button_config_time_path(valve_id))
+        if isinstance(value, int):
+            return value
+        return None
+
+    def build_refresh_button_config_time_obj(
+        self: _ButtonTimeDeviceProtocol, valve_id: int = 0
+    ) -> EgressMessageList:
+        return self.build_read_value_obj(self._button_config_time_path(valve_id))
+
+    def build_set_button_config_time_obj(
+        self: _ButtonTimeDeviceProtocol, seconds: int, valve_id: int = 0
+    ) -> EgressMessageList:
+        return self.build_write_value_obj(
+            self._button_config_time_path(valve_id), seconds
+        )
+
+
 class _Gen1Irrigation(Gen1Device, ABC):
     @property
     @abstractmethod
@@ -171,8 +226,11 @@ class Gen1WaterControl(
     Gen1IdentifyMixin,
     Gen1FrostWarningMixin,
     Gen1IrrigationScheduleMixin,
+    ButtonTimeMixin,
     _Gen1Irrigation,
 ):
+    _button_time_ipso_names = ("lemonbeat", "button_config_time")
+
     @property
     def valve_count(self) -> int:
         return 1
@@ -183,16 +241,7 @@ class Gen1WaterControl(
 
     @property
     def button_config_time(self) -> int | None:
-        value = self.get_value(
-            IpsoPath(
-                object_name="lemonbeat",
-                object_instance_id="0",
-                resource_name="button_config_time",
-            )
-        )
-        if isinstance(value, int):
-            return value
-        return None
+        return self.get_button_config_time()
 
     @property
     def temperature(self) -> int | None:
@@ -209,25 +258,6 @@ class Gen1WaterControl(
 
     def build_close_all_valves_obj(self) -> EgressMessageList:
         return self.build_close_valve_obj()
-
-    def build_read_button_config_time_obj(self) -> EgressMessageList:
-        return self.build_read_value_obj(
-            IpsoPath(
-                object_name="lemonbeat",
-                object_instance_id="0",
-                resource_name="button_config_time",
-            )
-        )
-
-    def build_set_button_config_time_obj(self, seconds: int) -> EgressMessageList:
-        return self.build_write_value_obj(
-            IpsoPath(
-                object_name="lemonbeat",
-                object_instance_id="0",
-                resource_name="button_config_time",
-            ),
-            seconds,
-        )
 
 
 class Gen1IrrigationControl(
@@ -326,8 +356,10 @@ class _Gen2Irrigation(Gen2Device):
         return None
 
 
-class Gen2WaterControl(Gen2BatteryMixin, Gen2TemperatureMixin, _Gen2Irrigation):
-    pass
+class Gen2WaterControl(
+    Gen2BatteryMixin, Gen2TemperatureMixin, ButtonTimeMixin, _Gen2Irrigation
+):
+    _button_time_ipso_names = ("actuator", "default_duration_seconds")
 
 
 class Gen2IrrigationControl(_Gen2Irrigation):

--- a/gardena_smart_local_api/examples/irrigation.py
+++ b/gardena_smart_local_api/examples/irrigation.py
@@ -8,6 +8,7 @@ import asyncio
 import sys
 
 from gardena_smart_local_api.devices import (
+    ButtonTimeMixin,
     Gen1IrrigationControl,
     Gen1WaterControl,
     Gen2IrrigationControl,
@@ -25,13 +26,23 @@ COMPATIBLE = (
     Gen2WaterControl,
 )
 
+DEFAULT_START_DURATION = 60
+
 
 async def main():
     extra_args = [
         {
             "name_or_flags": ["command"],
             "nargs": 1,
-            "choices": ("list", "start", "stop", "clear-schedules", "read-schedules"),
+            "choices": (
+                "list",
+                "start",
+                "stop",
+                "clear-schedules",
+                "read-schedules",
+                "read-button-time",
+                "set-button-time",
+            ),
             "help": "List devices, start/stop watering, or read/clear schedules",
         },
         {
@@ -43,9 +54,11 @@ async def main():
         {
             "name_or_flags": ["duration"],
             "nargs": "?",
-            "default": 60,
+            "default": DEFAULT_START_DURATION,
             "type": int,
-            "help": "Duration to water in seconds (default: 60s)",
+            "help": "Duration to water in seconds "
+            f"(start, default: {DEFAULT_START_DURATION}s) or button "
+            "time in seconds (set-button-time, required)",
         },
     ]
 
@@ -60,9 +73,15 @@ async def main():
                 assert isinstance(irrigation_device, COMPATIBLE)
 
                 try:
+                    valve_id = app.args.valve_id if app.args.valve_id is not None else 0
+                    duration_seconds = (
+                        app.args.duration
+                        if app.args.duration is not None
+                        else DEFAULT_START_DURATION
+                    )
                     request = irrigation_device.build_open_valve_obj(
-                        app.args.valve_id if app.args.valve_id is not None else 0,
-                        app.args.duration,
+                        valve_id,
+                        duration_seconds,
                     )
                 except ValueError:
                     print(f"Invalid valve ID provided: {app.args.valve_id}")
@@ -149,6 +168,81 @@ async def main():
                     assert irrigation_device.schedule_config is not None
                     raw = irrigation_device.schedule_config.hex()
                     print(f"{irrigation_device.schedule_count} schedule(s), raw: {raw}")
+
+            case "read-button-time":
+                if (irrigation_device := app.device) is None:
+                    return 1
+                assert isinstance(irrigation_device, COMPATIBLE)
+
+                if isinstance(irrigation_device, ButtonTimeMixin):
+                    # Query one specific valve if given, else all valves.
+                    if app.args.valve_id is not None:
+                        valve_ids = [app.args.valve_id]
+                    else:
+                        valve_ids = irrigation_device.valve_ids
+                    try:
+                        requests = [
+                            irrigation_device.build_refresh_button_config_time_obj(
+                                valve_id
+                            )
+                            for valve_id in valve_ids
+                        ]
+                    except ValueError:
+                        print(f"Invalid valve ID provided: {app.args.valve_id}")
+                        return 1
+                    request = requests[0]
+                    for r in requests[1:]:
+                        request = request + r
+                else:
+                    print("read-button-time not supported on this device")
+                    return 1
+
+                result = await app.send_request(request)
+                if result is None or not all(r.success for r in result):
+                    print("Failed to read button time")
+                    if result is not None:
+                        for r in result:
+                            if isinstance(r, ErrorMessage):
+                                print(f"Error: {r.error_message}")
+                    return 1
+
+                if isinstance(irrigation_device, ButtonTimeMixin):
+                    for valve_id in irrigation_device.valve_ids:
+                        button_time = irrigation_device.get_button_config_time(valve_id)
+                        print(f"Valve {valve_id} button time: {button_time}s")
+
+            case "set-button-time":
+                if (irrigation_device := app.device) is None:
+                    return 1
+                assert isinstance(irrigation_device, COMPATIBLE)
+
+                if app.args.duration is None:
+                    print(
+                        "set-button-time requires a valve ID and duration: "
+                        "set-button-time <valve_id> <duration in seconds>"
+                    )
+                    return 1
+
+                valve_id = app.args.valve_id if app.args.valve_id is not None else 0
+
+                if isinstance(irrigation_device, ButtonTimeMixin):
+                    try:
+                        request = irrigation_device.build_set_button_config_time_obj(
+                            app.args.duration, valve_id
+                        )
+                    except ValueError:
+                        print(f"Invalid valve ID provided: {app.args.valve_id}")
+                        return 1
+                else:
+                    print("set-button-time not supported on this device")
+                    return 1
+
+                result = await app.send_request(request)
+                if result is None or not result[0].success:
+                    print("Failed to set button time")
+                    if result is not None and isinstance(result[0], ErrorMessage):
+                        print(f"Error: {result[0].error_message}")
+                    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows reading and setting the default watering duration for the manual button on Gen2 water control / irrigation control valves, matching existing Gen1 support.