### PR TITLE
Fix gen1 Irrigation Control name

### DIFF
--- a/gardena_smart_local_api/schema/31653_irrigation_control.yaml
+++ b/gardena_smart_local_api/schema/31653_irrigation_control.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-name: Irrigation Control
+name: smart Irrigation Control
 protocol: gen1
 commands:
   measure_rf_link: 7


### PR DESCRIPTION
Just as gen2, the gen1 device was marketed as 'smart Irrigation Control'.