### PR TITLE
Declare license in project metadata, bump to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["gardena_smart_local_api"]
 
 [project]
 name = "gardena-smart-local-api"
-version = "0.1.0"
+version = "0.1.1"
 description = "Library to interact with the local GARDENA smart API."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ version = "0.1.0"
 description = "Library to interact with the local GARDENA smart API."
 readme = "README.md"
 requires-python = ">=3.12"
+license = "LGPL-3.0-or-later"
+license-files = ["LICENSES/LGPL-3.0-or-later.txt"]
 dependencies = [
     "aiofile>=3.9",
     "pydantic>=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "gardena-smart-local-api"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
PyPI (and downstream license checks) can't detect the license without a project.license field; REUSE compliance alone doesn't populate it.