### PR TITLE
Add identify support for Gen2 devices

### DIFF
--- a/gardena_smart_local_api/devices/gen2.py
+++ b/gardena_smart_local_api/devices/gen2.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Protocol
 
 from pydantic import Field
 
+from ..messages import EgressMessageList
 from ..model_loader import Gen2ModelDefinition
 from ..resources import VALUE_TYPES, IpsoPath
 from .device import Device
@@ -15,6 +16,10 @@ class _DeviceProtocol(Protocol):
     """Used to satisfy the type checker."""
 
     def get_value(self, path: IpsoPath) -> VALUE_TYPES | None: ...
+
+    def build_execute_obj(
+        self, path: IpsoPath, value: VALUE_TYPES | None
+    ) -> EgressMessageList: ...
 
 
 class Gen2BatteryMixin:
@@ -52,6 +57,18 @@ class Gen2TemperatureMixin:
             )
         )
         return value if isinstance(value, float) else None
+
+
+class Gen2IdentifyMixin:
+    def build_identify_obj(self: _DeviceProtocol) -> EgressMessageList:
+        return self.build_execute_obj(
+            IpsoPath(
+                object_name="sg_common",
+                object_instance_id="0",
+                resource_name="identify",
+            ),
+            None,
+        )
 
 
 class Gen2Device(Device):

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -15,7 +15,7 @@ from .gen1 import (
     Gen1IdentifyMixin,
     _Gen1DeviceProtocol,
 )
-from .gen2 import Gen2BatteryMixin, Gen2Device, Gen2TemperatureMixin
+from .gen2 import Gen2BatteryMixin, Gen2Device, Gen2IdentifyMixin, Gen2TemperatureMixin
 
 # Used to indicate that the action was initiated through WebSocket API.
 COMMAND_SOURCE = "18"
@@ -278,7 +278,7 @@ class Gen1IrrigationControl(
         return self.build_command_obj(self.get_command("close_all_valves"))
 
 
-class _Gen2Irrigation(Gen2Device):
+class _Gen2Irrigation(Gen2IdentifyMixin, Gen2Device):
     @property
     def valve_count(self) -> int:
         return len(self.valve_ids)


### PR DESCRIPTION
## Summary
- Gen2 water controls and irrigation control expose an `sg_common/identify` execute resource, but only Gen1 devices had `build_identify_obj` via `Gen1IdentifyMixin`
- Adds `Gen2IdentifyMixin` with the Gen2 equivalent, wired into `_Gen2Irrigation`

Fixes cloudless-garden/ha-gardena-smart-local-preview#67