### PR TITLE
Fix Gen1 is_valve_open to detect scheduled watering

### DIFF
--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -202,7 +202,7 @@ class _Gen1Irrigation(Gen1Device, ABC):
             raise ValueError(f"Invalid valve ID {valve_id}")
         value = self.get_watering_timer(valve_id)
         if value is not None:
-            return value > 0
+            return value != 0
         return None
 
     def build_open_valve_obj(

--- a/tests/test_gen1.py
+++ b/tests/test_gen1.py
@@ -10,6 +10,7 @@ from gardena_smart_local_api.devices.gen1 import (
     Gen1Device,
 )
 from gardena_smart_local_api.devices.irrigation import Gen1WaterControl
+from gardena_smart_local_api.messages import IngressMessageList
 
 
 @pytest.mark.asyncio
@@ -76,3 +77,29 @@ async def test_gen1_build_command_obj(water_control):
     assert request.entity.path.object_instance_id == "0"
     assert request.entity.path.resource_name == "command"
     assert request.payload == {"vi": 3}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("watering_timer", "expected"),
+    [(3597, True), (-3597, True), (0, False)],
+)
+async def test_gen1_is_valve_open_scheduled_watering(
+    water_control, watering_timer, expected
+):
+    event = IngressMessageList.model_validate_json(f"""
+        [
+          {{
+            "entity": {{ "device": "{water_control.id}", "path": "lemonbeat/0" }},
+            "metadata": {{ "sequence": 1, "source": "lemonbeatd" }},
+            "op": "update",
+            "payload": {{
+              "watering_timer_1": {{ "ts": 1774970419, "vi": {watering_timer} }},
+              "_urn": "urn:oma:lwm2m:x:31000"
+            }}
+          }}
+        ]
+        """)
+    water_control.update_data(event.root[0])
+
+    assert water_control.is_valve_open(0) is expected


### PR DESCRIPTION
## Summary

- `watering_timer_N` read encodes priority in the sign: positive = manual, negative = scheduled, 0 = stopped
- `is_valve_open` only checked `value > 0`, so scheduled watering left the valve reported as closed
- Fix checks `value != 0` instead
- Applies to both `Gen1WaterControl` and `Gen1IrrigationControl` (both inherit `_Gen1Irrigation`)

Fixes #83