### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["gardena_smart_local_api"]
 
 [project]
 name = "gardena-smart-local-api"
-version = "0.1.1"
+version = "0.1.2"
 description = "Library to interact with the local GARDENA smart API."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "gardena-smart-local-api"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofile" },


### PR DESCRIPTION
## Summary

- Bump version 0.1.1 -> 0.1.2 for release
- Includes since v0.1.1:
  - Fix Gen1 is_valve_open to detect scheduled watering (#84)
  - Add schedule config encoder
  - Add schedule config parser to utils
  - Add identify support for Gen2 devices