### PR TITLE
Add RF link quality support for Gen2 water/irrigation controls

### DIFF
--- a/gardena_smart_local_api/devices/gen2.py
+++ b/gardena_smart_local_api/devices/gen2.py
@@ -72,5 +72,42 @@ class Gen2IdentifyMixin:
 
 
 class Gen2Device(Device):
+    # connectivity_monitoring is present in every known Gen2 model schema.
     model_definition: Gen2ModelDefinition = Field()
     service: ClassVar[str] = "lwm2mserver"
+
+    @property
+    def radio_signal_strength(self: _DeviceProtocol) -> int | None:
+        """Signal strength in dBm, from the standard LwM2M connectivity object.
+
+        Also refreshed by build_refresh_rf_link_quality_obj().
+        """
+        value = self.get_value(
+            IpsoPath(
+                object_name="connectivity_monitoring",
+                object_instance_id="0",
+                resource_name="radio_signal_strength",
+            )
+        )
+        return value if isinstance(value, int) else None
+
+    @property
+    def rf_link_quality(self: _DeviceProtocol) -> int | None:
+        value = self.get_value(
+            IpsoPath(
+                object_name="connectivity_monitoring",
+                object_instance_id="0",
+                resource_name="link_quality",
+            )
+        )
+        return value if isinstance(value, int) else None
+
+    def build_refresh_rf_link_quality_obj(self: _DeviceProtocol) -> EgressMessageList:
+        return self.build_execute_obj(
+            IpsoPath(
+                object_name="sg_common",
+                object_instance_id="0",
+                resource_name="measure_rf_link",
+            ),
+            None,
+        )

--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -15,7 +15,12 @@ from .gen1 import (
     Gen1IdentifyMixin,
     _Gen1DeviceProtocol,
 )
-from .gen2 import Gen2BatteryMixin, Gen2Device, Gen2IdentifyMixin, Gen2TemperatureMixin
+from .gen2 import (
+    Gen2BatteryMixin,
+    Gen2Device,
+    Gen2IdentifyMixin,
+    Gen2TemperatureMixin,
+)
 
 # Used to indicate that the action was initiated through WebSocket API.
 COMMAND_SOURCE = "18"

--- a/gardena_smart_local_api/examples/device.py
+++ b/gardena_smart_local_api/examples/device.py
@@ -97,6 +97,8 @@ async def info(app: ExampleApp) -> int:
         out += f"\n  Battery:         {battery_level}%"
     if (rf_link_quality := getattr(device, "rf_link_quality", None)) is not None:
         out += f"\n  RF link quality: {rf_link_quality}%"
+    if (signal_strength := getattr(device, "radio_signal_strength", None)) is not None:
+        out += f"\n  Radio signal strength: {signal_strength} dBm"
     print(out)
     return 0
 

--- a/tests/test_gen2.py
+++ b/tests/test_gen2.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+import pytest
+
+from gardena_smart_local_api.devices.gen2 import Gen2Device
+from gardena_smart_local_api.messages import IngressMessageList
+from gardena_smart_local_api.model_loader import Gen2ModelDefinition
+
+
+@pytest.fixture
+def gen2_device():
+    return Gen2Device(
+        id="3034F8319C02BF00000033FF",
+        data={},
+        model_definition=Gen2ModelDefinition(
+            model_number="test-model", name="Test Gen2 Device"
+        ),
+    )
+
+
+def test_radio_signal_strength_and_link_quality_unset(gen2_device):
+    assert gen2_device.radio_signal_strength is None
+    assert gen2_device.rf_link_quality is None
+
+
+def test_radio_signal_strength_and_link_quality_from_event(gen2_device):
+    # Values as reported by a real Gen2 water control (single valve).
+    path = "connectivity_monitoring/0"
+    event = IngressMessageList.model_validate_json(f"""
+        [
+          {{
+            "entity": {{ "device": "{gen2_device.id}", "path": "{path}" }},
+            "metadata": {{ "sequence": 1, "source": "lwm2mserver" }},
+            "op": "update",
+            "payload": {{
+              "radio_signal_strength": {{ "ts": 1786352015, "vi": -73 }},
+              "link_quality": {{ "ts": 1786352015, "vi": 2 }},
+              "_urn": "urn:oma:lwm2m:x:28171"
+            }}
+          }}
+        ]
+        """)
+    gen2_device.update_data(event.root[0])
+
+    assert gen2_device.radio_signal_strength == -73
+    assert gen2_device.rf_link_quality == 2
+
+
+def test_build_refresh_rf_link_quality_obj(gen2_device):
+    request_list = gen2_device.build_refresh_rf_link_quality_obj()
+    request = request_list.root[0]
+
+    assert request.op == "execute"
+    assert request.entity.device == gen2_device.id
+    assert request.entity.service == "lwm2mserver"
+    assert request.entity.path.object_name == "sg_common"
+    assert request.entity.path.object_instance_id == "0"
+    assert request.entity.path.resource_name == "measure_rf_link"


### PR DESCRIPTION
Gen1 devices expose RF link quality directly on `Gen1Device`, Gen2 had no equivalent. Added `radio_signal_strength` and `rf_link_quality` read from the standard LwM2M Connectivity Monitoring object, plus `build_refresh_rf_link_quality_obj()` to trigger a fresh reading (mirrors Gen1's method of the same name).

Confirmed against a real Gen2 water control (single valve) via gateway logs, values match exactly:
```
sg_common/0/measure_rf_link                       execute, triggers a measurement
connectivity_monitoring/0/radio_signal_strength    dBm
connectivity_monitoring/0/link_quality             small int scale
```

Lives directly on `Gen2Device` rather than as a per-subclass mixin: all 5 known Gen2 model schemas (water controls, irrigation controls, mowers) declare `connectivity_monitoring`, so it's universal across Gen2, not device-type-specific.

`device.py`'s generic info printer picks it up automatically too (same `getattr` pattern as `rf_link_quality`).

Only field-tested on a water control so far. @ezra, if you have a Gen2 mower handy, would be great to confirm it reports these too, otherwise we're assuming it works there based on the schema alone. Not a critical feature either way.

Closes #88
