### PR TITLE
Reject manual pump start/stop while in automatic mode

### DIFF
--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -385,6 +385,13 @@ class Pump(
     def build_start_obj(
         self, duration_seconds: int = DEFAULT_WATERING_DURATION
     ) -> EgressMessageList:
+        # In automatic mode the pump decides for itself based on outlet
+        # pressure and ignores manual start/stop writes, so sending one
+        # would silently do nothing.
+        if self.operating_mode == PumpOperatingMode.AUTOMATIC:
+            raise ValueError(
+                "Cannot manually start/stop the pump while it's in automatic mode"
+            )
         return self.build_write_value_obj(
             IpsoPath(
                 object_name="lemonbeat",

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+import pytest
+
+from gardena_smart_local_api.devices.irrigation import Pump, PumpOperatingMode
+from gardena_smart_local_api.model_loader import Gen1ModelDefinition
+
+
+@pytest.fixture
+def pump():
+    return Pump(
+        id="3034F8319C02BF00000033FF",
+        data={},
+        model_definition=Gen1ModelDefinition(model_number="22538", name="Test Pump"),
+    )
+
+
+def _set_operating_mode(pump, mode: PumpOperatingMode) -> None:
+    pump.data.setdefault("lemonbeat", {}).setdefault("0", {})["operating_mode"] = {
+        "vi": mode.value
+    }
+
+
+def test_build_start_obj(pump):
+    request = pump.build_start_obj(120).root[0]
+    assert request.op == "write"
+    assert request.entity.device == pump.id
+    assert request.entity.path.object_name == "lemonbeat"
+    assert request.entity.path.object_instance_id == "0"
+    assert request.entity.path.resource_name == "watering_timer_1"
+    assert request.payload == {"vi": 120}
+
+
+def test_build_stop_obj(pump):
+    request = pump.build_stop_obj().root[0]
+    assert request.payload == {"vi": 0}
+
+
+def test_build_start_obj_raises_in_automatic_mode(pump):
+    _set_operating_mode(pump, PumpOperatingMode.AUTOMATIC)
+    with pytest.raises(ValueError, match="automatic mode"):
+        pump.build_start_obj(120)
+
+
+def test_build_stop_obj_raises_in_automatic_mode(pump):
+    _set_operating_mode(pump, PumpOperatingMode.AUTOMATIC)
+    with pytest.raises(ValueError, match="automatic mode"):
+        pump.build_stop_obj()
+
+
+def test_build_start_obj_allowed_in_scheduled_mode(pump):
+    _set_operating_mode(pump, PumpOperatingMode.SCHEDULED)
+    request = pump.build_start_obj(120).root[0]
+    assert request.payload == {"vi": 120}
+
+
+def test_build_start_obj_allowed_when_mode_unset(pump):
+    request = pump.build_start_obj(120).root[0]
+    assert request.payload == {"vi": 120}


### PR DESCRIPTION
In automatic mode the pump decides for itself based on outlet
pressure (runs when below `turn_on_pressure`) and ignores manual
start/stop writes, so a caller that doesn't check `operating_mode`
first would silently send a command the pump just drops.

`build_start_obj` now raises `ValueError` if `operating_mode ==
PumpOperatingMode.AUTOMATIC`; `build_stop_obj` goes through it too
(`build_start_obj(0)`), so both are covered. Protects any consumer
of the lib, not just the HA integration.

Follow-up to cloudless-garden/ha-gardena-smart-local-preview#105,
which added the same guard at the HA integration layer — this moves
the check down into the lib so it's not integration-specific.