### PR TITLE
Fix: report flow_rate=0 when pump is not running

### DIFF
--- a/gardena_smart_local_api/devices/irrigation.py
+++ b/gardena_smart_local_api/devices/irrigation.py
@@ -521,6 +521,11 @@ class Pump(
 
     @property
     def flow_rate(self) -> int | None:
+        # The device can report values from 100 to 13615. Therefore, even when the pump
+        # is not running, a value of 100 gets reported.
+        # The following condition avoids passing on obviously wrong values.
+        if self.is_running is False:
+            return 0
         value = self.get_value(
             IpsoPath(
                 object_name="lemonbeat",

--- a/tests/test_epp.py
+++ b/tests/test_epp.py
@@ -63,7 +63,7 @@ async def test_epp_outlet_temperature(epp):
 
 @pytest.mark.asyncio
 async def test_epp_flow_rate(epp):
-    assert epp.flow_rate == 100
+    assert epp.flow_rate == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The gateway reports a default/calibration value of 100 L/h for flow_rate even when the pump is stopped. This mirrors the fix i've already applied in the Home Assistant integration (cloudless-garden/ha-gardena-smart-local-preview#113) by using the existing is_running property to short-circuit and return 0 when the pump is confirmed off (while still returning None if the running state hasn't been read yet.)

Should resolve the issue https://github.com/cloudless-garden/gardena-smart-local-api/issues/93